### PR TITLE
パスワード検索画面の最新パスワード取得アクションを実装

### DIFF
--- a/src/api/services/password/__tests__/passwordService.test.ts
+++ b/src/api/services/password/__tests__/passwordService.test.ts
@@ -1,4 +1,44 @@
-import { extractPasswordIndexRows } from '../passwordService';
+import apiClient from '@/api/client';
+import { extractPasswordIndexRows, PasswordService } from '../passwordService';
+
+describe('PasswordService.latest', () => {
+  it('account_id ありで最新パスワード取得APIを呼び出せる', async () => {
+    jest.spyOn(apiClient, 'get').mockResolvedValue({
+      success: true,
+      data: { password: 'secret' },
+    });
+
+    const response = await PasswordService.latest({
+      application_id: 10,
+      account_id: 20,
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.data).toEqual({ password: 'secret' });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/passwords/latest?application_id=10&account_id=20',
+      undefined
+    );
+  });
+
+  it('account_id なしで最新パスワード取得APIを呼び出せる', async () => {
+    jest.spyOn(apiClient, 'get').mockResolvedValue({
+      success: true,
+      data: { password: 'secret' },
+    });
+
+    const response = await PasswordService.latest({
+      application_id: 10,
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.data).toEqual({ password: 'secret' });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/passwords/latest?application_id=10',
+      undefined
+    );
+  });
+});
 
 describe('extractPasswordIndexRows', () => {
   it('application/account ネスト構造を一覧表示用に整形できる', () => {

--- a/src/api/services/password/passwordService.ts
+++ b/src/api/services/password/passwordService.ts
@@ -58,6 +58,15 @@ export type PasswordCreateApiResponse =
       errors?: PasswordCreateValidationError;
     };
 
+export interface PasswordLatestRequest {
+  application_id: number;
+  account_id?: number;
+}
+
+export interface PasswordLatestResponse {
+  password?: string;
+}
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
@@ -137,5 +146,20 @@ export class PasswordService {
     }
 
     return response;
+  }
+
+  static async latest(
+    request: PasswordLatestRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<PasswordLatestResponse>> {
+    const query = new URLSearchParams({
+      application_id: `${request.application_id}`,
+    });
+
+    if (typeof request.account_id === 'number') {
+      query.set('account_id', `${request.account_id}`);
+    }
+
+    return apiClient.get(`/passwords/latest?${query.toString()}`, config);
   }
 }

--- a/src/app/passwords/_components/PasswordList.tsx
+++ b/src/app/passwords/_components/PasswordList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useTransition } from 'react';
+import React, { useState, useTransition } from 'react';
 import Title from '@/components/Title';
 import PasswordTable from './PasswordTable';
 import { useRouter } from 'next/navigation';
@@ -9,7 +9,11 @@ import Image from 'next/image';
 import ArrowDown from '@/assets/images/arrow/arrowDown.svg';
 import { ErrorMessage } from '@/components/form/ErrorMessage';
 import { useQueryState } from 'nuqs';
-import { PasswordApplicationOption, PasswordIndexRow } from '../types';
+import {
+  PasswordActionMessage,
+  PasswordApplicationOption,
+  PasswordIndexRow,
+} from '../types';
 import { passwordApplicationIdParser } from '../_lib/searchParams';
 
 type PasswordListProps = {
@@ -29,6 +33,8 @@ const PasswordList: React.FC<PasswordListProps> = ({
 }) => {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [actionMessage, setActionMessage] =
+    useState<PasswordActionMessage | null>(null);
   const [applicationId, setApplicationId] = useQueryState(
     'application_id',
     passwordApplicationIdParser.withOptions({
@@ -47,6 +53,7 @@ const PasswordList: React.FC<PasswordListProps> = ({
     event: React.ChangeEvent<HTMLSelectElement>
   ) => {
     const value = event.target.value;
+    setActionMessage(null);
     void setApplicationId(value ? Number(value) : null);
   };
 
@@ -85,10 +92,21 @@ const PasswordList: React.FC<PasswordListProps> = ({
         </p>
       )}
 
+      {actionMessage?.type === 'success' && (
+        <p className="mb-4 text-sm text-green-600" aria-live="polite">
+          {actionMessage.text}
+        </p>
+      )}
+
+      {actionMessage?.type === 'error' && (
+        <ErrorMessage message={actionMessage.text} className="mb-4" />
+      )}
+
       {errorMessage && <ErrorMessage message={errorMessage} className="mb-4" />}
 
       <PasswordTable
         rows={rows}
+        onActionMessage={setActionMessage}
         emptyMessage={
           errorMessage
             ? 'パスワード一覧を表示できません。'

--- a/src/app/passwords/_components/PasswordTable.tsx
+++ b/src/app/passwords/_components/PasswordTable.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { Th, TableRowWrapper } from '@/components/table';
-import { PasswordIndexRow } from '../types';
+import { PasswordActionMessage, PasswordIndexRow } from '../types';
 import PasswordTr from './PasswordTr';
 
 type PasswordTableProps = {
   rows: PasswordIndexRow[];
+  onActionMessage: (message: PasswordActionMessage | null) => void;
   emptyMessage?: string;
 };
 
 const PasswordTable: React.FC<PasswordTableProps> = ({
   rows,
+  onActionMessage,
   emptyMessage = '表示できるパスワードはありません。',
 }) => {
   const headerStyle = { backgroundColor: '#3E3E3E', borderColor: '#3E3E3E' };
@@ -49,6 +51,7 @@ const PasswordTable: React.FC<PasswordTableProps> = ({
               <PasswordTr
                 key={`${row.application_id}-${row.account_id ?? 'none'}`}
                 row={row}
+                onActionMessage={onActionMessage}
               />
             ))
           )}

--- a/src/app/passwords/_components/PasswordTr.tsx
+++ b/src/app/passwords/_components/PasswordTr.tsx
@@ -1,18 +1,81 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import { Td, TableRowWrapper } from '@/components/table';
-import { PasswordIndexRow } from '../types';
-import Button from '@/components/Button';
+import { PasswordService } from '@/api/services/password/passwordService';
+import { PasswordActionMessage, PasswordIndexRow } from '../types';
 import { formatDateTimeToMinute } from '@/lib/dateFormat';
 
 type PasswordTrProps = {
   row: PasswordIndexRow;
+  onActionMessage: (message: PasswordActionMessage | null) => void;
 };
 
-const PasswordTr: React.FC<PasswordTrProps> = ({ row }) => {
+const PASSWORD_NOT_FOUND_MESSAGE =
+  '最新パスワードが見つかりません。条件を確認してください。';
+const PASSWORD_COPY_SUCCESS_MESSAGE = 'パスワードをコピーしました。';
+const PASSWORD_COPY_ERROR_MESSAGE = 'パスワードのコピーに失敗しました。';
+
+const PasswordTr: React.FC<PasswordTrProps> = ({ row, onActionMessage }) => {
   const borderStyle = { borderColor: '#d1d5db' };
-  const handleDetailClick = () => {
-    // パスワード取得導線は別Issueで実装予定。
-    console.log('Copying password to clipboard');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleGetLatestPassword = async () => {
+    if (isLoading) {
+      return;
+    }
+
+    onActionMessage(null);
+    setIsLoading(true);
+
+    const response = await PasswordService.latest({
+      application_id: row.application_id,
+      ...(typeof row.account_id === 'number'
+        ? { account_id: row.account_id }
+        : {}),
+    });
+
+    setIsLoading(false);
+
+    if (!response.success) {
+      onActionMessage({
+        type: 'error',
+        text:
+          response.error?.status === 404
+            ? PASSWORD_NOT_FOUND_MESSAGE
+            : response.error?.message ?? '最新パスワードの取得に失敗しました。',
+      });
+      return;
+    }
+
+    const latestPassword = response.data?.password;
+    if (!latestPassword) {
+      onActionMessage({
+        type: 'error',
+        text: PASSWORD_NOT_FOUND_MESSAGE,
+      });
+      return;
+    }
+
+    try {
+      if (
+        typeof navigator === 'undefined' ||
+        typeof navigator.clipboard?.writeText !== 'function'
+      ) {
+        throw new Error('Clipboard API is unavailable');
+      }
+
+      await navigator.clipboard.writeText(latestPassword);
+      onActionMessage({
+        type: 'success',
+        text: PASSWORD_COPY_SUCCESS_MESSAGE,
+      });
+    } catch {
+      onActionMessage({
+        type: 'error',
+        text: PASSWORD_COPY_ERROR_MESSAGE,
+      });
+    }
   };
 
   return (
@@ -41,7 +104,14 @@ const PasswordTr: React.FC<PasswordTrProps> = ({ row }) => {
       </Td>
 
       <Td className="text-center">
-        <Button text="取得" onClick={handleDetailClick} />
+        <button
+          type="button"
+          onClick={handleGetLatestPassword}
+          disabled={isLoading}
+          className="text-white px-6 py-3 rounded text-sm font-medium bg-[#3CB371] hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-opacity duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isLoading ? '取得中...' : '取得'}
+        </button>
       </Td>
     </TableRowWrapper>
   );

--- a/src/app/passwords/_components/__tests__/PasswordTr.test.tsx
+++ b/src/app/passwords/_components/__tests__/PasswordTr.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PasswordService } from '@/api/services/password/passwordService';
+import PasswordTr from '../PasswordTr';
+
+describe('PasswordTr', () => {
+  const onActionMessage = jest.fn();
+  const row = {
+    application_id: 10,
+    account_id: 20,
+    latest_updated_at: '2026-03-08T12:34:00+09:00',
+    application_name: 'GitHub',
+    account_name: 'octocat',
+  };
+
+  beforeEach(() => {
+    onActionMessage.mockReset();
+  });
+
+  it('取得成功時にコピー完了メッセージを表示する', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PasswordService, 'latest').mockResolvedValue({
+      success: true,
+      data: { password: 'secret-password' },
+    });
+
+    render(
+      <table>
+        <tbody>
+          <PasswordTr row={row} onActionMessage={onActionMessage} />
+        </tbody>
+      </table>
+    );
+
+    await user.click(screen.getByRole('button', { name: '取得' }));
+
+    await waitFor(() => {
+      expect(PasswordService.latest).toHaveBeenCalledWith({
+        application_id: 10,
+        account_id: 20,
+      });
+      expect(onActionMessage).toHaveBeenLastCalledWith({
+        type: 'success',
+        text: 'パスワードをコピーしました。',
+      });
+    });
+  });
+
+  it('account_id が null のときは application_id のみで取得する', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PasswordService, 'latest').mockResolvedValue({
+      success: true,
+      data: { password: 'secret-password' },
+    });
+
+    render(
+      <table>
+        <tbody>
+          <PasswordTr
+            row={{ ...row, account_id: null, account_name: 'アカウントなし' }}
+            onActionMessage={onActionMessage}
+          />
+        </tbody>
+      </table>
+    );
+
+    await user.click(screen.getByRole('button', { name: '取得' }));
+
+    await waitFor(() => {
+      expect(PasswordService.latest).toHaveBeenCalledWith({
+        application_id: 10,
+      });
+    });
+  });
+
+  it('404 時は共通文言を表示する', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PasswordService, 'latest').mockResolvedValue({
+      success: false,
+      error: { message: 'not found', status: 404 },
+    });
+
+    render(
+      <table>
+        <tbody>
+          <PasswordTr row={row} onActionMessage={onActionMessage} />
+        </tbody>
+      </table>
+    );
+
+    await user.click(screen.getByRole('button', { name: '取得' }));
+
+    await waitFor(() => {
+      expect(onActionMessage).toHaveBeenLastCalledWith({
+        type: 'error',
+        text: '最新パスワードが見つかりません。条件を確認してください。',
+      });
+    });
+  });
+
+  it('クリップボードAPIが使えない場合はエラーメッセージを表示する', async () => {
+    const user = userEvent.setup();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    jest.spyOn(PasswordService, 'latest').mockResolvedValue({
+      success: true,
+      data: { password: 'secret-password' },
+    });
+
+    render(
+      <table>
+        <tbody>
+          <PasswordTr row={row} onActionMessage={onActionMessage} />
+        </tbody>
+      </table>
+    );
+
+    await user.click(screen.getByRole('button', { name: '取得' }));
+
+    await waitFor(() => {
+      expect(onActionMessage).toHaveBeenLastCalledWith({
+        type: 'error',
+        text: 'パスワードのコピーに失敗しました。',
+      });
+    });
+  });
+});

--- a/src/app/passwords/types/index.ts
+++ b/src/app/passwords/types/index.ts
@@ -4,3 +4,8 @@ export interface PasswordApplicationOption {
   id: number;
   name: string;
 }
+
+export interface PasswordActionMessage {
+  type: 'success' | 'error';
+  text: string;
+}


### PR DESCRIPTION
## 概要
- パスワード検索一覧の `取得` ボタンから最新パスワード取得APIを呼び出す処理を実装
- 取得した最新パスワードは画面表示せず、そのままクリップボードへコピーする動作に変更
- 成功/失敗メッセージと404共通文言、二重実行防止を追加

## 変更内容
- `PasswordService.latest` を追加して `GET /api/v2/passwords/latest` を呼び出せるようにした
- `account_id` は一覧行の値に応じて送信有無を切り替えるようにした
- `取得` 成功時は `パスワードをコピーしました。` を画面上部に表示
- `404` は条件違反/データなしを同一文言で扱うようにした
- 取得中の多重リクエストを抑止した
- パスワードの行内表示とコピーボタンは廃止した
- 一覧画面とサービス層のテストを追加・更新した

## テスト
- `npm test -- --runInBand src/api/services/password/__tests__/passwordService.test.ts src/app/passwords/_components/__tests__/PasswordList.test.tsx src/app/passwords/_components/__tests__/PasswordTr.test.tsx`
- `npx tsc --noEmit`