### PR TITLE
パスワード登録画面のフォーム連動と登録API接続を実装

### DIFF
--- a/src/app/passwords/create/_components/PasswordForm.tsx
+++ b/src/app/passwords/create/_components/PasswordForm.tsx
@@ -1,39 +1,121 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useActionState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import SubmitButton from '@/components/button/SubmitButton';
 import CancelButton from '@/components/button/CancelButton';
 import ArrowDown from '@/assets/images/arrow/arrowDown.svg';
-import { AccountApplicationOption } from '@/api/services/account/accountService';
-import NumberInput from '@/components/NumberInput';
+import {
+  AccountIndexRow,
+} from '@/api/services/account/accountService';
+import { Application } from '@/api/services/application/applicationService';
 import Button from '@/components/Button';
+import NumberInput from '@/components/NumberInput';
+import {
+  createPassword,
+  FormState,
+} from '../action/PasswordCreateActions';
 
-interface AccountFormProps {
-  applications: AccountApplicationOption[];
+interface PasswordFormProps {
+  applications: Pick<Application, 'id' | 'name' | 'mark_class'>[];
+  accounts: AccountIndexRow[];
 }
 
-const AccountForm: React.FC<AccountFormProps> = ({ applications }) => {
+const generatePassword = (size: number, includeSymbols: boolean): string => {
+  const chars = includeSymbols
+    ? 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*'
+    : 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+  return Array.from({ length: size }, () => {
+    const index = Math.floor(Math.random() * chars.length);
+    return chars[index];
+  }).join('');
+};
+
+const PasswordForm: React.FC<PasswordFormProps> = ({ applications, accounts }) => {
+  const router = useRouter();
+  const initialState: FormState = {
+    errors: undefined,
+    success: false,
+    shouldRedirect: false,
+  };
+  const [state, formAction, isPending] = useActionState(
+    createPassword,
+    initialState
+  );
+  const [password, setPassword] = useState('');
+  const [selectedApplicationId, setSelectedApplicationId] = useState('');
+  const [selectedAccountId, setSelectedAccountId] = useState('');
+  const [passwordSize, setPasswordSize] = useState(10);
+
+  const filteredAccounts = useMemo(
+    () =>
+      accounts.filter(
+        (account) => `${account.application_id}` === selectedApplicationId
+      ),
+    [accounts, selectedApplicationId]
+  );
+  const selectedApplication = useMemo(
+    () =>
+      applications.find(
+        (application) => `${application.id}` === selectedApplicationId
+      ),
+    [applications, selectedApplicationId]
+  );
+
+  useEffect(() => {
+    if (
+      selectedAccountId &&
+      !filteredAccounts.some((account) => `${account.id}` === selectedAccountId)
+    ) {
+      setSelectedAccountId('');
+    }
+  }, [filteredAccounts, selectedAccountId]);
+
+  useEffect(() => {
+    if (!state.shouldRedirect) {
+      return;
+    }
+
+    const timerId = window.setTimeout(() => {
+      router.push('/passwords');
+    }, 800);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [router, state.shouldRedirect]);
+
   return (
-    <form className="px-6 space-y-6 text-[20px]">
+    <form action={formAction} className="px-6 space-y-6 text-[20px]">
       {/* パスワード */}
       <div>
         <div className="flex gap-12">
           <label className="block text-gray-700 font-medium mb-3">
             パスワード
           </label>
-          <Button text="生成" onClick={() => {}} />
+          <Button
+            text="生成"
+            onClick={() =>
+              setPassword(
+                generatePassword(passwordSize, selectedApplication?.mark_class ?? false)
+              )
+            }
+          />
         </div>
         <input
           type="text"
           name="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
           className="w-[97%] m-4 text-black px-4 py-3 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent"
         />
-        <div className="text-red-500 text-sm mt-1 ml-4">
-          {'バリデーションエラー'}
-        </div>
+        {state.errors?.password?.password && (
+          <div className="text-red-500 text-sm mt-1 ml-4">
+            {state.errors.password.password.join(', ')}
+          </div>
+        )}
       </div>
 
       {/* アプリケーション */}
@@ -44,12 +126,11 @@ const AccountForm: React.FC<AccountFormProps> = ({ applications }) => {
         <div className="relative w-[97%] m-4 py-3">
           <select
             name="application_id"
-            defaultValue=""
+            value={selectedApplicationId}
+            onChange={(event) => setSelectedApplicationId(event.target.value)}
             className="w-full text-black px-4 py-3 pr-12 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent appearance-none"
           >
-            <option value="" disabled>
-              選択してください
-            </option>
+            <option value="">選択してください</option>
             {applications.map((application) => (
               <option key={application.id} value={application.id}>
                 {application.name}
@@ -60,9 +141,11 @@ const AccountForm: React.FC<AccountFormProps> = ({ applications }) => {
             <Image src={ArrowDown} alt="選択" width={16} height={16} />
           </div>
         </div>
-        <div className="text-red-500 text-sm mt-1 ml-4">
-          {'バリデーションエラー'}
-        </div>
+        {state.errors?.password?.application_id && (
+          <div className="text-red-500 text-sm mt-1 ml-4">
+            {state.errors.password.application_id.join(', ')}
+          </div>
+        )}
       </div>
 
       {/* アカウント名 */}
@@ -73,15 +156,19 @@ const AccountForm: React.FC<AccountFormProps> = ({ applications }) => {
         <div className="relative w-[97%] m-4 py-3">
           <select
             name="account_id"
-            defaultValue=""
-            className="w-full text-black px-4 py-3 pr-12 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent appearance-none"
+            value={selectedAccountId}
+            onChange={(event) => setSelectedAccountId(event.target.value)}
+            disabled={!selectedApplicationId || filteredAccounts.length === 0}
+            className="w-full text-black px-4 py-3 pr-12 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent appearance-none disabled:bg-gray-100 disabled:text-gray-500"
           >
-            <option value="" disabled>
-              選択してください
+            <option value="">
+              {selectedApplicationId
+                ? '選択してください'
+                : '先にアプリケーションを選択してください'}
             </option>
-            {applications.map((application) => (
-              <option key={application.id} value={application.id}>
-                {application.name}
+            {filteredAccounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name}
               </option>
             ))}
           </select>
@@ -89,27 +176,33 @@ const AccountForm: React.FC<AccountFormProps> = ({ applications }) => {
             <Image src={ArrowDown} alt="選択" width={16} height={16} />
           </div>
         </div>
-        <div className="text-red-500 text-sm mt-1 ml-4">
-          {'バリデーションエラー'}
-        </div>
+        {state.errors?.password?.account_id && (
+          <div className="text-red-500 text-sm mt-1 ml-4">
+            {state.errors.password.account_id.join(', ')}
+          </div>
+        )}
       </div>
 
       {/* パスワード桁数 */}
       <div className="flex items-center gap-[74px]">
         <label className="text-gray-700 font-medium mb-3">パスワード桁数</label>
-        <NumberInput name="password_size" defaultValue={10} min={1} step={1} />
-        <div className="text-red-500 text-sm mt-1 ml-4">
-          {'バリデーションエラー'}
-        </div>
+        <NumberInput
+          name="password_size"
+          defaultValue={10}
+          value={passwordSize}
+          min={1}
+          step={1}
+          onChange={setPasswordSize}
+        />
       </div>
 
       {/* ボタン部分 */}
       <div className="flex justify-center mt-14 gap-32">
         <CancelButton to="/passwords" />
-        <SubmitButton isSubmit text="登録" />
+        <SubmitButton isSubmit text="登録" disabled={isPending} />
       </div>
     </form>
   );
 };
 
-export default AccountForm;
+export default PasswordForm;

--- a/src/app/passwords/create/_components/__tests__/PasswordForm.test.tsx
+++ b/src/app/passwords/create/_components/__tests__/PasswordForm.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useActionState } from 'react';
+import { useRouter } from 'next/navigation';
+import PasswordForm from '../PasswordForm';
+import { FormState } from '../../action/PasswordCreateActions';
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    useActionState: jest.fn(),
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('next/image', () => {
+  return function MockImage({
+    src,
+    alt,
+    width,
+    height,
+  }: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+  }) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt} width={width} height={height} />;
+  };
+});
+
+jest.mock('@/components/button/SubmitButton', () => {
+  return function MockSubmitButton({
+    text,
+    isSubmit,
+    disabled,
+  }: {
+    text: string;
+    isSubmit?: boolean;
+    disabled?: boolean;
+  }) {
+    return (
+      <button type={isSubmit ? 'submit' : 'button'} disabled={disabled}>
+        {text}
+      </button>
+    );
+  };
+});
+
+jest.mock('@/components/button/CancelButton', () => {
+  return function MockCancelButton({ to }: { to: string }) {
+    return <a href={to}>キャンセル</a>;
+  };
+});
+
+jest.mock('@/components/Button', () => {
+  return function MockButton({
+    text,
+    onClick,
+  }: {
+    text: string;
+    onClick: () => void;
+  }) {
+    return <button onClick={onClick}>{text}</button>;
+  };
+});
+
+describe('PasswordForm', () => {
+  const mockPush = jest.fn();
+  const mockFormAction = jest.fn();
+  const applications = [
+    { id: 1, name: 'アプリA', mark_class: true },
+    { id: 2, name: 'アプリB', mark_class: false },
+  ];
+  const accounts = [
+    {
+      id: 10,
+      name: 'account-a1',
+      application_id: 1,
+      application_name: 'アプリA',
+      notice_class: false,
+    },
+    {
+      id: 20,
+      name: 'account-a2',
+      application_id: 1,
+      application_name: 'アプリA',
+      notice_class: true,
+    },
+    {
+      id: 30,
+      name: 'account-b1',
+      application_id: 2,
+      application_name: 'アプリB',
+      notice_class: false,
+    },
+  ];
+
+  const mockUseActionState = useActionState as jest.MockedFunction<
+    typeof useActionState
+  >;
+  const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+  beforeEach(() => {
+    const initialState: FormState = {
+      errors: undefined,
+      success: false,
+      shouldRedirect: false,
+    };
+    mockUseActionState.mockReturnValue([initialState, mockFormAction, false]);
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+    } as ReturnType<typeof useRouter>);
+    mockPush.mockReset();
+  });
+
+  it('アプリ選択に応じてアカウント候補が連動する', async () => {
+    const user = userEvent.setup();
+
+    render(<PasswordForm applications={applications} accounts={accounts} />);
+
+    const selects = screen.getAllByRole('combobox');
+    const applicationSelect = selects[0];
+    const accountSelect = selects[1];
+
+    expect(accountSelect).toBeDisabled();
+
+    await user.selectOptions(applicationSelect, '1');
+
+    expect(accountSelect).not.toBeDisabled();
+    expect(screen.getByRole('option', { name: 'account-a1' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'account-a2' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'account-b1' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('success 時は一覧へ遷移する', () => {
+    mockUseActionState.mockReturnValue([
+      {
+        errors: undefined,
+        success: true,
+        shouldRedirect: true,
+      },
+      mockFormAction,
+      false,
+    ]);
+
+    render(<PasswordForm applications={applications} accounts={accounts} />);
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('mark_class=true のアプリでは記号入りパスワードを生成する', async () => {
+    const user = userEvent.setup();
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    render(<PasswordForm applications={applications} accounts={accounts} />);
+
+    const selects = screen.getAllByRole('combobox');
+    await user.selectOptions(selects[0], '1');
+    await user.click(screen.getByRole('button', { name: '生成' }));
+
+    const passwordInput = screen.getByRole('textbox') as HTMLInputElement;
+    expect(passwordInput.value).toMatch(/[!@#$%^&*]/);
+
+    randomSpy.mockRestore();
+  });
+
+  it('mark_class=false のアプリでは記号なしパスワードを生成する', async () => {
+    const user = userEvent.setup();
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    render(<PasswordForm applications={applications} accounts={accounts} />);
+
+    const selects = screen.getAllByRole('combobox');
+    await user.selectOptions(selects[0], '2');
+    await user.click(screen.getByRole('button', { name: '生成' }));
+
+    const passwordInput = screen.getByRole('textbox') as HTMLInputElement;
+    expect(passwordInput.value).not.toMatch(/[!@#$%^&*]/);
+
+    randomSpy.mockRestore();
+  });
+});

--- a/src/app/passwords/create/action/PasswordCreateActions.ts
+++ b/src/app/passwords/create/action/PasswordCreateActions.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import {
+  PasswordCreateValidationError,
+  PasswordService,
+} from '@/api/services/password/passwordService';
+import { getServerAuthConfig } from '@/lib/serverAuthConfig';
+
+export interface FormState {
+  errors?: PasswordCreateValidationError;
+  success?: boolean;
+  shouldRedirect?: boolean;
+}
+
+export async function createPassword(
+  prevState: FormState,
+  formData: FormData
+): Promise<FormState> {
+  void prevState;
+
+  const password = (formData.get('password') as string | null)?.trim() ?? '';
+  const applicationIdRaw = formData.get('application_id') as string | null;
+  const accountIdRaw = formData.get('account_id') as string | null;
+  const applicationId = applicationIdRaw ? Number(applicationIdRaw) : NaN;
+  const accountId = accountIdRaw ? Number(accountIdRaw) : NaN;
+
+  const authConfig = await getServerAuthConfig();
+  const response = await PasswordService.create(
+    {
+      password: {
+        password,
+        application_id: applicationId,
+        account_id: accountId,
+      },
+    },
+    authConfig
+  );
+
+  if ('errors' in response && response.errors) {
+    return {
+      errors: response.errors,
+      success: false,
+      shouldRedirect: false,
+    };
+  }
+
+  if ('success' in response && !response.success) {
+    if (response.error?.status === 401) {
+      redirect('/login');
+    }
+
+    return {
+      errors: {
+        password: {
+          password: [response.error?.message ?? '登録に失敗しました。'],
+        },
+      },
+      success: false,
+      shouldRedirect: false,
+    };
+  }
+
+  return {
+    success: true,
+    shouldRedirect: true,
+  };
+}

--- a/src/app/passwords/create/action/__tests__/PasswordCreateActions.test.ts
+++ b/src/app/passwords/create/action/__tests__/PasswordCreateActions.test.ts
@@ -1,0 +1,92 @@
+import { createPassword } from '../PasswordCreateActions';
+import { PasswordService } from '@/api/services/password/passwordService';
+import { getServerAuthConfig } from '@/lib/serverAuthConfig';
+
+jest.mock('@/api/services/password/passwordService', () => ({
+  PasswordService: {
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/serverAuthConfig', () => ({
+  getServerAuthConfig: jest.fn(),
+}));
+
+describe('createPassword', () => {
+  const mockCreate = PasswordService.create as jest.MockedFunction<
+    typeof PasswordService.create
+  >;
+  const mockGetServerAuthConfig = getServerAuthConfig as jest.MockedFunction<
+    typeof getServerAuthConfig
+  >;
+
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockGetServerAuthConfig.mockReset();
+    mockGetServerAuthConfig.mockResolvedValue({
+      headers: {
+        Authorization: 'Bearer token',
+      },
+    });
+  });
+
+  it('正しい payload で登録APIを呼び出す', async () => {
+    mockCreate.mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    const formData = new FormData();
+    formData.set('password', 'secret');
+    formData.set('application_id', '10');
+    formData.set('account_id', '20');
+
+    const result = await createPassword({}, formData);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      {
+        password: {
+          password: 'secret',
+          application_id: 10,
+          account_id: 20,
+        },
+      },
+      {
+        headers: {
+          Authorization: 'Bearer token',
+        },
+      }
+    );
+    expect(result).toEqual({
+      success: true,
+      shouldRedirect: true,
+    });
+  });
+
+  it('未入力時はフィールド単位でエラーを返す', async () => {
+    mockCreate.mockResolvedValue({
+      errors: {
+        password: {
+          password: ['パスワードを入力してください。'],
+          application_id: ['アプリケーションを選択してください。'],
+          account_id: ['アカウントを選択してください。'],
+        },
+      },
+    });
+
+    const formData = new FormData();
+
+    const result = await createPassword({}, formData);
+
+    expect(mockCreate).toHaveBeenCalled();
+    expect(result.errors?.password?.password).toEqual([
+      'パスワードを入力してください。',
+    ]);
+    expect(result.errors?.password?.application_id).toEqual([
+      'アプリケーションを選択してください。',
+    ]);
+    expect(result.errors?.password?.account_id).toEqual([
+      'アカウントを選択してください。',
+    ]);
+  });
+});

--- a/src/app/passwords/create/page.tsx
+++ b/src/app/passwords/create/page.tsx
@@ -1,16 +1,113 @@
 import Title from '@/components/Title';
 import {
-  AccountApplicationOption,
+  AccountIndexRow,
   AccountService,
 } from '@/api/services/account/accountService';
+import {
+  Application,
+  ApplicationService,
+} from '@/api/services/application/applicationService';
 import { getServerAuthConfig } from '@/lib/serverAuthConfig';
 import PasswordForm from './_components/PasswordForm';
+import { redirect } from 'next/navigation';
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const extractApplications = (
+  value: unknown
+): Pick<Application, 'id' | 'name' | 'mark_class'>[] => {
+  const list = Array.isArray(value)
+    ? value
+    : isObject(value) && Array.isArray(value.data)
+      ? value.data
+      : [];
+
+  return list
+    .map((item) => {
+      if (!isObject(item)) {
+        return null;
+      }
+
+      const id = item.id;
+      const name = item.name;
+      const markClass = item.mark_class;
+      if (
+        typeof id !== 'number' ||
+        typeof name !== 'string' ||
+        typeof markClass !== 'boolean'
+      ) {
+        return null;
+      }
+
+      return { id, name, mark_class: markClass };
+    })
+    .filter(
+      (item): item is Pick<Application, 'id' | 'name' | 'mark_class'> =>
+        item !== null
+    );
+};
+
+const extractAccounts = (value: unknown): AccountIndexRow[] => {
+  const list = Array.isArray(value)
+    ? value
+    : isObject(value) && Array.isArray(value.data)
+      ? value.data
+      : [];
+
+  return list
+    .map((item) => {
+      if (!isObject(item)) {
+        return null;
+      }
+
+      const id = item.id;
+      const name = item.name;
+      const applicationId = item.application_id;
+      const applicationName = item.application_name;
+      const noticeClass = item.notice_class;
+
+      if (
+        typeof id !== 'number' ||
+        typeof name !== 'string' ||
+        typeof applicationId !== 'number' ||
+        typeof applicationName !== 'string' ||
+        typeof noticeClass !== 'boolean'
+      ) {
+        return null;
+      }
+
+      return {
+        id,
+        name,
+        application_id: applicationId,
+        application_name: applicationName,
+        notice_class: noticeClass,
+      };
+    })
+    .filter((item): item is AccountIndexRow => item !== null);
+};
 
 const PasswordCreatePage = async () => {
   const authConfig = await getServerAuthConfig();
-  const res = await AccountService.applications(authConfig);
-  const applications: AccountApplicationOption[] = Array.isArray(res.data)
-    ? res.data
+  const [applicationsResponse, accountsResponse] = await Promise.all([
+    ApplicationService.index(authConfig),
+    AccountService.index(authConfig),
+  ]);
+
+  if (
+    (!applicationsResponse.success &&
+      applicationsResponse.error?.status === 401) ||
+    (!accountsResponse.success && accountsResponse.error?.status === 401)
+  ) {
+    redirect('/login');
+  }
+
+  const applications = applicationsResponse.success
+    ? extractApplications(applicationsResponse.data)
+    : [];
+  const accounts = accountsResponse.success
+    ? extractAccounts(accountsResponse.data)
     : [];
 
   return (
@@ -21,7 +118,7 @@ const PasswordCreatePage = async () => {
       </div>
 
       {/* フォーム部分 */}
-      <PasswordForm applications={applications} />
+      <PasswordForm applications={applications} accounts={accounts} />
     </main>
   );
 };

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -8,30 +8,42 @@ import ArrowDown from '@/assets/images/arrow/arrowDown.svg';
 interface NumberInputProps {
   name: string;
   defaultValue?: number;
+  value?: number;
   min?: number;
   step?: number;
+  onChange?: (value: number) => void;
 }
 
 const NumberInput: React.FC<NumberInputProps> = ({
   name,
   defaultValue = 10,
+  value,
   min = 1,
   step = 1,
+  onChange,
 }) => {
-  const [value, setValue] = useState(defaultValue);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const currentValue = value ?? internalValue;
+
+  const updateValue = (nextValue: number) => {
+    if (value === undefined) {
+      setInternalValue(nextValue);
+    }
+    onChange?.(nextValue);
+  };
 
   const handleIncrement = () => {
-    setValue((prev) => prev + step);
+    updateValue(currentValue + step);
   };
 
   const handleDecrement = () => {
-    setValue((prev) => Math.max(min, prev - step));
+    updateValue(Math.max(min, currentValue - step));
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = parseInt(e.target.value);
     if (!isNaN(newValue) && newValue >= min) {
-      setValue(newValue);
+      updateValue(newValue);
     }
   };
 
@@ -40,7 +52,7 @@ const NumberInput: React.FC<NumberInputProps> = ({
       <input
         type="number"
         name={name}
-        value={value}
+        value={currentValue}
         onChange={handleInputChange}
         min={min}
         step={step}

--- a/src/components/button/SubmitButton.tsx
+++ b/src/components/button/SubmitButton.tsx
@@ -2,13 +2,15 @@ interface SubmitButtonProps {
   onClick?: () => void;
   isSubmit?: boolean;
   text: string;
+  disabled?: boolean;
 }
 
 export default function SubmitButton(props: SubmitButtonProps) {
   return (
     <button
-      className="text-white w-36 px-6 py-3 rounded bg-[#3CB371] text-[18px] font-medium hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-opacity duration-200"
+      className="text-white w-36 px-6 py-3 rounded bg-[#3CB371] text-[18px] font-medium hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-opacity duration-200 disabled:cursor-not-allowed disabled:opacity-60"
       type={props.isSubmit ? 'submit' : 'button'}
+      disabled={props.disabled}
       onClick={props.onClick ?? (() => {})}
     >
       {props.text}


### PR DESCRIPTION
## 概要
- パスワード登録画面のフォームを本実装へ差し替え
- application/account の連動と `POST /api/v2/passwords` 接続を追加
- パスワード生成を `mark_class` 条件に応じて切り替え

## 変更内容
- `PasswordForm` を `useActionState` ベースに変更
- アプリ選択に応じてアカウント候補を絞り込み、不整合入力を防止
- `PasswordCreateActions` を追加し、登録APIへ正しい payload を送信
- `422` フィールドエラーはバックエンド返却内容をそのまま表示
- `401` はログイン遷移へ委譲
- 送信中のボタン非活性化を追加
- `password_size` は UI 補助のまま、送信はしない仕様に整理
- `mark_class=true` のアプリは記号入り、false は記号なしで生成するようにした
- アプリ一覧取得を全アプリ対象に修正
- `NumberInput` を制御コンポーネントとして扱えるよう拡張

## テスト
- `npm test -- --runInBand src/app/passwords/create/action/__tests__/PasswordCreateActions.test.ts src/app/passwords/create/_components/__tests__/PasswordForm.test.tsx`
- `npx tsc --noEmit`