### PR TITLE
[codex] Implement mobile header and menu layout

### DIFF
--- a/src/app/(main)/MainShell.tsx
+++ b/src/app/(main)/MainShell.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import Header from '@/components/Header';
+import Sidebar from '@/components/Sidebar';
+
+type MainShellProps = {
+  children: ReactNode;
+  userName: string;
+};
+
+export default function MainShell({ children, userName }: MainShellProps) {
+  const pathname = usePathname();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    document.body.style.overflow = isMobileMenuOpen ? 'hidden' : '';
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isMobileMenuOpen]);
+
+  const handleMobileMenuToggle = () => {
+    setIsMobileMenuOpen((current) => !current);
+  };
+
+  const handleMobileNavigate = () => {
+    setIsMobileMenuOpen(false);
+  };
+
+  return (
+    <>
+      <Header
+        userName={userName}
+        isMobileMenuOpen={isMobileMenuOpen}
+        onMobileMenuToggle={handleMobileMenuToggle}
+      />
+      <div className="relative flex">
+        <Sidebar
+          isMobileMenuOpen={isMobileMenuOpen}
+          onMobileNavigate={handleMobileNavigate}
+        />
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
 import { cookies } from 'next/headers';
-import Header from '@/components/Header';
-import Sidebar from '@/components/Sidebar';
 import AuthSessionGuard from './AuthSessionGuard';
+import MainShell from './MainShell';
 
 type MainLayoutProps = {
   children: ReactNode;
@@ -15,11 +14,7 @@ export default async function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="min-h-screen bg-gray-100">
       <AuthSessionGuard />
-      <Header userName={userName ?? 'ゲスト'} />
-      <div className="flex">
-        <Sidebar />
-        {children}
-      </div>
+      <MainShell userName={userName ?? 'ゲスト'}>{children}</MainShell>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,20 +81,65 @@ const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
 
   return (
     <header
-      className="text-white p-4 flex justify-between items-center w-full"
+      className="text-white flex justify-between items-center w-full px-4 py-3 md:p-4"
       style={{ backgroundColor: '#3E3E3E' }}
     >
-      <h1 className="text-xl font-bold">{appName}</h1>
+      <div className="flex items-center gap-3">
+        {props.onMobileMenuToggle && (
+          <button
+            type="button"
+            onClick={props.onMobileMenuToggle}
+            className="flex h-8 w-8 items-center justify-center rounded md:hidden"
+            aria-label={
+              props.isMobileMenuOpen
+                ? 'メニューを閉じる'
+                : 'メニューを開く'
+            }
+            aria-expanded={props.isMobileMenuOpen}
+            aria-controls="mobile-navigation"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              className="h-6 w-6"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M3 18V16H21V18H3ZM3 13V11H21V13H3ZM3 8V6H21V8H3Z" fill="white" />
+            </svg>
+          </button>
+        )}
+        <h1 className="text-xl font-bold">{appName}</h1>
+      </div>
       <div className="flex items-center gap-3">
         <span className="text-xl">{userName}</span>
         {userName !== 'ゲスト' && (
-          <button
-            type="button"
-            onClick={handleLogout}
-            className="px-3 py-1 text-sm border border-white rounded hover:bg-white hover:text-[#3E3E3E] transition-colors"
-          >
-            ログアウト
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="hidden px-3 py-1 text-sm border border-white rounded hover:bg-white hover:text-[#3E3E3E] transition-colors md:inline-flex"
+            >
+              ログアウト
+            </button>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="flex h-8 w-8 -mr-[5px] items-center justify-center rounded md:hidden"
+              aria-label="ログアウト"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                className="h-6 w-6"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 21C4.45 21 3.97917 20.8042 3.5875 20.4125C3.19583 20.0208 3 19.55 3 19V5C3 4.45 3.19583 3.97917 3.5875 3.5875C3.97917 3.19583 4.45 3 5 3H12V5H5V19H12V21H5ZM16 17L14.625 15.55L17.175 13H9V11H17.175L14.625 8.45L16 7L21 12L16 17Z"
+                  fill="white"
+                />
+              </svg>
+            </button>
+          </>
         )}
       </div>
     </header>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,7 +6,11 @@ import { usePathname } from 'next/navigation';
 import { SidebarProps } from '@/types/sidebar';
 import { extractMenuItems, MenuService } from '@/api/services/menu/menuService';
 
-const Sidebar: React.FC<SidebarProps> = ({ className }) => {
+const Sidebar: React.FC<SidebarProps> = ({
+  className,
+  isMobileMenuOpen,
+  onMobileNavigate,
+}) => {
   const pathname = usePathname();
   const [menuItems, setMenuItems] = useState<{ name: string; path: string }[]>(
     []
@@ -37,37 +41,69 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
   }
 
   return (
-    <nav
-      className={`w-48 text-white min-h-screen ${className ?? ''}`.trim()}
-      style={{ backgroundColor: '#3E3E3E' }}
-      role="navigation"
-      aria-label="メインナビゲーション"
-    >
-      {menuItems.map((item) => (
-        <Link
-          key={item.path}
-          href={item.path}
-          className={`block w-full text-left px-4 py-4 text-sm cursor-pointer border-b border-gray-600 relative transition-colors duration-200 ${
-            pathname.includes(item.path)
-              ? 'font-medium'
-              : 'hover:bg-gray-600'
-          }`}
-          style={
-            pathname.includes(item.path) ? { backgroundColor: '#555555' } : {}
-          }
-          aria-current={pathname.includes(item.path) ? 'page' : undefined}
+    <>
+      <nav
+        className={`hidden w-48 min-h-screen text-white md:block ${
+          className ?? ''
+        }`.trim()}
+        style={{ backgroundColor: '#3E3E3E' }}
+        role="navigation"
+        aria-label="メインナビゲーション"
+      >
+        {menuItems.map((item) => (
+          <Link
+            key={item.path}
+            href={item.path}
+            className={`block w-full text-left px-4 py-4 text-sm cursor-pointer border-b border-gray-600 relative transition-colors duration-200 ${
+              pathname.includes(item.path) ? 'font-medium' : 'hover:bg-gray-600'
+            }`}
+            style={
+              pathname.includes(item.path) ? { backgroundColor: '#555555' } : {}
+            }
+            aria-current={pathname.includes(item.path) ? 'page' : undefined}
+          >
+            {item.name}
+            {pathname.includes(item.path) && (
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1"
+                style={{ backgroundColor: '#3CB371' }}
+                aria-hidden="true"
+              />
+            )}
+          </Link>
+        ))}
+      </nav>
+      {isMobileMenuOpen && (
+        <div
+          className="fixed inset-x-0 bottom-0 top-14 z-40 bg-black/10 md:hidden"
+          onClick={onMobileNavigate}
         >
-          {item.name}
-          {pathname.includes(item.path) && (
-            <div
-              className="absolute right-0 top-0 bottom-0 w-1"
-              style={{ backgroundColor: '#3CB371' }}
-              aria-hidden="true"
-            />
-          )}
-        </Link>
-      ))}
-    </nav>
+          <div
+            id="mobile-navigation"
+            className="mx-5 mt-4 overflow-hidden border border-white text-white shadow-lg"
+            style={{ backgroundColor: '#3E3E3E' }}
+            role="navigation"
+            aria-label="モバイルメインナビゲーション"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {menuItems.map((item) => (
+              <Link
+                key={item.path}
+                href={item.path}
+                className={`block w-full px-4 py-5 text-center text-[18px] border-b border-gray-300 last:border-b-0 active:bg-[#555555] ${
+                  pathname.includes(item.path) ? 'font-medium' : ''
+                }`}
+                style={{ backgroundColor: '#3E3E3E' }}
+                aria-current={pathname.includes(item.path) ? 'page' : undefined}
+                onClick={onMobileNavigate}
+              >
+                {item.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Header from '../Header';
+import { AuthService } from '@/api/services/auth/authService';
+import { apiClient } from '@/api';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/passwords'),
+  useRouter: jest.fn(() => ({
+    push: mockPush,
+  })),
+}));
+
+jest.mock('@/api', () => ({
+  apiClient: {
+    clearAuthToken: jest.fn(),
+  },
+}));
+
+jest.mock('@/api/services/auth/authService', () => ({
+  AuthService: {
+    loginStatus: jest.fn(),
+    logout: jest.fn(),
+  },
+  extractUserName: jest.fn((value: { name?: string }) => value.name ?? null),
+  extractUserNameFromToken: jest.fn(() => null),
+}));
+
+describe('Header', () => {
+  beforeEach(() => {
+    const mockedLoginStatus = AuthService.loginStatus as jest.Mock;
+    const mockedLogout = AuthService.logout as jest.Mock;
+    const mockedClearAuthToken = apiClient.clearAuthToken as jest.Mock;
+
+    mockPush.mockReset();
+    mockedLoginStatus.mockReset();
+    mockedLogout.mockReset();
+    mockedClearAuthToken.mockReset();
+
+    mockedLoginStatus.mockResolvedValue({
+      success: true,
+      data: { name: '本園 裕哉' },
+    });
+    mockedLogout.mockResolvedValue({ success: true });
+  });
+
+  it('モバイル用のメニュー開閉ボタンとログアウトアイコンを表示する', async () => {
+    const onMobileMenuToggle = jest.fn();
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation((key: string) => {
+        if (key === 'auth_token') {
+          return 'header.test.token';
+        }
+
+        if (key === 'auth_user_name') {
+          return '本園 裕哉';
+        }
+
+        return null;
+      });
+
+    render(
+      <Header
+        userName="本園 裕哉"
+        isMobileMenuOpen={false}
+        onMobileMenuToggle={onMobileMenuToggle}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'メニューを開く' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'ログアウト' })).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'メニューを開く' }));
+    expect(onMobileMenuToggle).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'ログアウト' })[1]);
+
+    await waitFor(() => {
+      expect(AuthService.logout).toHaveBeenCalledTimes(1);
+      expect(apiClient.clearAuthToken).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+
+    getItemSpy.mockRestore();
+  });
+});

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import Sidebar from '../Sidebar';
+import { MenuService } from '@/api/services/menu/menuService';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: {
+    children: ReactNode;
+    href: string;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/passwords'),
+}));
+
+jest.mock('@/api/services/menu/menuService', () => ({
+  MenuService: {
+    index: jest.fn(),
+  },
+  extractMenuItems: jest.fn((value: { data?: { name: string; path: string }[] }) =>
+    value.data ?? []
+  ),
+}));
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    (MenuService.index as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        data: [
+          { name: 'パスワード検索', path: '/passwords' },
+          { name: '仮登録パスワード一覧', path: '/temp-passwords' },
+        ],
+      },
+    });
+  });
+
+  it('モバイルメニューが開いている時にドロワー形式でメニューを表示する', async () => {
+    render(<Sidebar isMobileMenuOpen={true} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('navigation', { name: 'モバイルメインナビゲーション' })
+      ).toBeInTheDocument();
+    });
+
+    const mobileNavigation = screen.getByRole('navigation', {
+      name: 'モバイルメインナビゲーション',
+    });
+
+    expect(within(mobileNavigation).getByText('パスワード検索')).toBeInTheDocument();
+    expect(
+      within(mobileNavigation).getByText('仮登録パスワード一覧')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/types/header.ts
+++ b/src/types/header.ts
@@ -1,3 +1,5 @@
 export interface HeaderProps {
   userName?: string;
+  isMobileMenuOpen?: boolean;
+  onMobileMenuToggle?: () => void;
 }

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -1,5 +1,7 @@
 export interface SidebarProps {
   className?: string;
+  isMobileMenuOpen?: boolean;
+  onMobileNavigate?: () => void;
 }
 
 export interface SidebarMenuItem {


### PR DESCRIPTION
## 概要
- Issue #109 のモバイル向けヘッダー・メニュー出し分けを実装
- PC レイアウトは維持したまま、モバイル時のみハンバーガーメニューとドロワー表示へ切り替え
- Figma 指定に合わせてハンバーガーアイコン、ログアウトアイコン、メニュータイル色を調整

## 変更内容
- `(main)` レイアウト配下に `MainShell` を追加し、モバイルメニュー開閉状態を集約
- `Header` にモバイル用ハンバーガーボタンとログアウトアイコンを追加
- `Sidebar` を PC 用サイドバーとモバイル用メニューパネルで出し分け
- モバイルメニューは遷移時に自動で閉じ、タップ時のみ `#555555` を適用
- `Header` / `Sidebar` の表示差分を検証するテストを追加

<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/b4ded28d-4ce0-4dbe-a0d6-e68137e6d47e" />

## 影響
- モバイル表示時のナビゲーション UI のみ変更
- PC 表示のヘッダー・サイドバー構成には変更なし

## 確認
- `npm run lint -- --quiet`
- `npx jest src/components/__tests__/Header.test.tsx src/components/__tests__/Sidebar.test.tsx --runInBand`
- `npm run build`

Closes #109