### PR TITLE
Add mobile card layouts for password lists

### DIFF
--- a/src/app/(main)/passwords/_components/PasswordList.tsx
+++ b/src/app/(main)/passwords/_components/PasswordList.tsx
@@ -58,15 +58,17 @@ const PasswordList: React.FC<PasswordListProps> = ({
   };
 
   return (
-    <main className="flex-1 p-6" role="main">
-      <div className="flex justify-between items-center mb-8">
+    <main className="flex-1 p-4 md:p-6" role="main">
+      <div className="mb-6 flex flex-col gap-4 md:mb-8 md:flex-row md:items-center md:justify-between [&_h2]:mb-0">
         <Title title={title} />
-        <SubmitButton onClick={handleCreateClick} text="新規登録" />
+        <div className="hidden w-full md:block md:w-auto">
+          <SubmitButton onClick={handleCreateClick} text="新規登録" />
+        </div>
       </div>
 
       {/* アプリケーション */}
-      <div>
-        <div className="relative w-[97%] m-4 py-3">
+      <div className="mb-6">
+        <div className="relative w-full py-0 md:m-4 md:w-[97%] md:py-3">
           <select
             name="application_id"
             value={resolvedApplicationId}

--- a/src/app/(main)/passwords/_components/PasswordTable.tsx
+++ b/src/app/(main)/passwords/_components/PasswordTable.tsx
@@ -17,47 +17,66 @@ const PasswordTable: React.FC<PasswordTableProps> = ({
   const headerStyle = { backgroundColor: '#3E3E3E', borderColor: '#3E3E3E' };
 
   return (
-    <div className="bg-white shadow overflow-hidden">
-      <table className="w-full" role="table" aria-label="パスワード検索">
-        <thead>
-          <TableRowWrapper className="text-white">
-            <Th className="border-r w-[130px]" style={headerStyle}>
-              更新日
-            </Th>
+    <>
+      <div className="space-y-4 md:hidden">
+        {rows.length === 0 ? (
+          <div className="rounded-md border border-[#D9D9D9] bg-white px-4 py-6 text-center text-gray-600 shadow-[8px_8px_0_rgba(0,0,0,0.18)]">
+            {emptyMessage}
+          </div>
+        ) : (
+          rows.map((row) => (
+            <PasswordTr
+              key={`${row.application_id}-${row.account_id ?? 'none'}-card`}
+              row={row}
+              onActionMessage={onActionMessage}
+              variant="card"
+            />
+          ))
+        )}
+      </div>
 
-            <Th className="border-r" style={headerStyle}>
-              アプリケーション名
-            </Th>
+      <div className="hidden overflow-hidden bg-white shadow md:block">
+        <table className="w-full" role="table" aria-label="パスワード検索">
+          <thead>
+            <TableRowWrapper className="text-white">
+              <Th className="border-r w-[130px]" style={headerStyle}>
+                更新日
+              </Th>
 
-            <Th className="border-r" style={headerStyle}>
-              アカウント名
-            </Th>
+              <Th className="border-r" style={headerStyle}>
+                アプリケーション名
+              </Th>
 
-            <Th className="w-[220px]" style={headerStyle}>
-              {''}
-            </Th>
-          </TableRowWrapper>
-        </thead>
+              <Th className="border-r" style={headerStyle}>
+                アカウント名
+              </Th>
 
-        <tbody className="divide-y divide-gray-200">
-          {rows.length === 0 ? (
-            <tr>
-              <td colSpan={4} className="px-6 py-6 text-center text-gray-600">
-                {emptyMessage}
-              </td>
-            </tr>
-          ) : (
-            rows.map((row) => (
-              <PasswordTr
-                key={`${row.application_id}-${row.account_id ?? 'none'}`}
-                row={row}
-                onActionMessage={onActionMessage}
-              />
-            ))
-          )}
-        </tbody>
-      </table>
-    </div>
+              <Th className="w-[220px]" style={headerStyle}>
+                {''}
+              </Th>
+            </TableRowWrapper>
+          </thead>
+
+          <tbody className="divide-y divide-gray-200">
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-6 py-6 text-center text-gray-600">
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <PasswordTr
+                  key={`${row.application_id}-${row.account_id ?? 'none'}-table`}
+                  row={row}
+                  onActionMessage={onActionMessage}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 };
 

--- a/src/app/(main)/passwords/_components/PasswordTable.tsx
+++ b/src/app/(main)/passwords/_components/PasswordTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Th, TableRowWrapper } from '@/components/table';
+import MobileEmptyState from '@/components/MobileEmptyState';
 import { PasswordActionMessage, PasswordIndexRow } from '../types';
 import PasswordTr from './PasswordTr';
 
@@ -20,9 +21,7 @@ const PasswordTable: React.FC<PasswordTableProps> = ({
     <>
       <div className="space-y-4 md:hidden">
         {rows.length === 0 ? (
-          <div className="rounded-md border border-[#D9D9D9] bg-white px-4 py-6 text-center text-gray-600 shadow-[8px_8px_0_rgba(0,0,0,0.18)]">
-            {emptyMessage}
-          </div>
+          <MobileEmptyState message={emptyMessage} />
         ) : (
           rows.map((row) => (
             <PasswordTr

--- a/src/app/(main)/passwords/_components/PasswordTr.tsx
+++ b/src/app/(main)/passwords/_components/PasswordTr.tsx
@@ -9,6 +9,7 @@ import { formatDateTimeToMinute } from '@/lib/dateFormat';
 type PasswordTrProps = {
   row: PasswordIndexRow;
   onActionMessage: (message: PasswordActionMessage | null) => void;
+  variant?: 'table' | 'card';
 };
 
 const PASSWORD_NOT_FOUND_MESSAGE =
@@ -16,7 +17,14 @@ const PASSWORD_NOT_FOUND_MESSAGE =
 const PASSWORD_COPY_SUCCESS_MESSAGE = 'パスワードをコピーしました。';
 const PASSWORD_COPY_ERROR_MESSAGE = 'パスワードのコピーに失敗しました。';
 
-const PasswordTr: React.FC<PasswordTrProps> = ({ row, onActionMessage }) => {
+const actionButtonClassName =
+  'text-white rounded text-sm font-medium bg-[#3CB371] hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-opacity duration-200 disabled:cursor-not-allowed disabled:opacity-60';
+
+const PasswordTr: React.FC<PasswordTrProps> = ({
+  row,
+  onActionMessage,
+  variant = 'table',
+}) => {
   const borderStyle = { borderColor: '#d1d5db' };
   const [isLoading, setIsLoading] = useState(false);
 
@@ -43,7 +51,8 @@ const PasswordTr: React.FC<PasswordTrProps> = ({ row, onActionMessage }) => {
         text:
           response.error?.status === 404
             ? PASSWORD_NOT_FOUND_MESSAGE
-            : response.error?.message ?? '最新パスワードの取得に失敗しました。',
+            : (response.error?.message ??
+              '最新パスワードの取得に失敗しました。'),
       });
       return;
     }
@@ -78,6 +87,42 @@ const PasswordTr: React.FC<PasswordTrProps> = ({ row, onActionMessage }) => {
     }
   };
 
+  if (variant === 'card') {
+    return (
+      <button
+        type="button"
+        onClick={handleGetLatestPassword}
+        disabled={isLoading}
+        className="block min-h-[150px] w-full max-w-[335px] rounded-md border border-[#334155] bg-white p-4 text-left shadow-[8px_8px_0_rgba(0,0,0,0.18)] transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <dl className="text-gray-900">
+          <div className="space-y-1">
+            <dd className="text-[15px] font-normal text-gray-900">
+              {`更新日: ${formatDateTimeToMinute(row.latest_updated_at)}`}
+            </dd>
+          </div>
+          <div
+            className="mb-3 mt-[3px] h-px w-full bg-[#334155]"
+            aria-hidden="true"
+          />
+          <div className="space-y-2">
+            <dd className="break-all text-[16px] font-semibold leading-6">
+              {`アプリケーション名: ${row.application_name}`}
+            </dd>
+          </div>
+          <div className="mt-2 space-y-2">
+            <dd className="break-all text-[16px] font-semibold leading-6">
+              {`アカウント名: ${row.account_name}`}
+            </dd>
+          </div>
+        </dl>
+        {isLoading && (
+          <p className="mt-4 text-sm font-medium text-[#3CB371]">取得中...</p>
+        )}
+      </button>
+    );
+  }
+
   return (
     <TableRowWrapper>
       <Td
@@ -108,7 +153,7 @@ const PasswordTr: React.FC<PasswordTrProps> = ({ row, onActionMessage }) => {
           type="button"
           onClick={handleGetLatestPassword}
           disabled={isLoading}
-          className="text-white px-6 py-3 rounded text-sm font-medium bg-[#3CB371] hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-opacity duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+          className={`${actionButtonClassName} px-6 py-3`}
         >
           {isLoading ? '取得中...' : '取得'}
         </button>

--- a/src/app/(main)/passwords/_components/PasswordTr.tsx
+++ b/src/app/(main)/passwords/_components/PasswordTr.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { Td, TableRowWrapper } from '@/components/table';
+import MobileInfoCard from '@/components/MobileInfoCard';
 import { PasswordService } from '@/api/services/password/passwordService';
 import { PasswordActionMessage, PasswordIndexRow } from '../types';
 import { formatDateTimeToMinute } from '@/lib/dateFormat';
@@ -89,37 +90,14 @@ const PasswordTr: React.FC<PasswordTrProps> = ({
 
   if (variant === 'card') {
     return (
-      <button
-        type="button"
+      <MobileInfoCard
         onClick={handleGetLatestPassword}
         disabled={isLoading}
-        className="block min-h-[150px] w-full max-w-[335px] rounded-md border border-[#334155] bg-white p-4 text-left shadow-[8px_8px_0_rgba(0,0,0,0.18)] transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        <dl className="text-gray-900">
-          <div className="space-y-1">
-            <dd className="text-[15px] font-normal text-gray-900">
-              {`更新日: ${formatDateTimeToMinute(row.latest_updated_at)}`}
-            </dd>
-          </div>
-          <div
-            className="mb-3 mt-[3px] h-px w-full bg-[#334155]"
-            aria-hidden="true"
-          />
-          <div className="space-y-2">
-            <dd className="break-all text-[16px] font-semibold leading-6">
-              {`アプリケーション名: ${row.application_name}`}
-            </dd>
-          </div>
-          <div className="mt-2 space-y-2">
-            <dd className="break-all text-[16px] font-semibold leading-6">
-              {`アカウント名: ${row.account_name}`}
-            </dd>
-          </div>
-        </dl>
-        {isLoading && (
-          <p className="mt-4 text-sm font-medium text-[#3CB371]">取得中...</p>
-        )}
-      </button>
+        headerText={`更新日: ${formatDateTimeToMinute(row.latest_updated_at)}`}
+        primaryText={`アプリケーション名: ${row.application_name}`}
+        secondaryText={`アカウント名: ${row.account_name}`}
+        statusText={isLoading ? '取得中...' : undefined}
+      />
     );
   }
 

--- a/src/app/(main)/passwords/_components/__tests__/PasswordList.test.tsx
+++ b/src/app/(main)/passwords/_components/__tests__/PasswordList.test.tsx
@@ -92,6 +92,8 @@ describe('PasswordList', () => {
     );
 
     expect(screen.getByText('入力データに問題があります。')).toBeInTheDocument();
-    expect(screen.getByText('パスワード一覧を表示できません。')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('パスワード一覧を表示できません。')
+    ).not.toHaveLength(0);
   });
 });

--- a/src/app/(main)/passwords/_components/__tests__/PasswordTr.test.tsx
+++ b/src/app/(main)/passwords/_components/__tests__/PasswordTr.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PasswordService } from '@/api/services/password/passwordService';
+import { formatDateTimeToMinute } from '@/lib/dateFormat';
 import PasswordTr from '../PasswordTr';
 
 describe('PasswordTr', () => {
@@ -144,7 +145,9 @@ describe('PasswordTr', () => {
       <PasswordTr row={row} onActionMessage={onActionMessage} variant="card" />
     );
 
-    expect(screen.getByText('更新日: 2026-03-08 12:34')).toBeInTheDocument();
+    expect(
+      screen.getByText(`更新日: ${formatDateTimeToMinute(row.latest_updated_at)}`)
+    ).toBeInTheDocument();
     expect(
       screen.getByText('アプリケーション名: GitHub')
     ).toBeInTheDocument();

--- a/src/app/(main)/passwords/_components/__tests__/PasswordTr.test.tsx
+++ b/src/app/(main)/passwords/_components/__tests__/PasswordTr.test.tsx
@@ -34,7 +34,7 @@ describe('PasswordTr', () => {
       </table>
     );
 
-    await user.click(screen.getByRole('button', { name: '取得' }));
+    await user.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(PasswordService.latest).toHaveBeenCalledWith({
@@ -67,7 +67,7 @@ describe('PasswordTr', () => {
       </table>
     );
 
-    await user.click(screen.getByRole('button', { name: '取得' }));
+    await user.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(PasswordService.latest).toHaveBeenCalledWith({
@@ -92,7 +92,7 @@ describe('PasswordTr', () => {
       </table>
     );
 
-    await user.click(screen.getByRole('button', { name: '取得' }));
+    await user.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(onActionMessage).toHaveBeenLastCalledWith({
@@ -128,6 +128,38 @@ describe('PasswordTr', () => {
       expect(onActionMessage).toHaveBeenLastCalledWith({
         type: 'error',
         text: 'パスワードのコピーに失敗しました。',
+      });
+    });
+  });
+
+  it('カード表示でも取得操作ができる', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PasswordService, 'latest').mockResolvedValue({
+      success: true,
+      data: { password: 'secret-password' },
+    });
+
+    render(
+      <PasswordTr row={row} onActionMessage={onActionMessage} variant="card" />
+    );
+
+    expect(screen.getByText('更新日: 2026-03-08 12:34')).toBeInTheDocument();
+    expect(
+      screen.getByText('アプリケーション名: GitHub')
+    ).toBeInTheDocument();
+    expect(screen.getByText('アカウント名: octocat')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(PasswordService.latest).toHaveBeenCalledWith({
+        application_id: 10,
+        account_id: 20,
+      });
+      expect(onActionMessage).toHaveBeenLastCalledWith({
+        type: 'success',
+        text: 'パスワードをコピーしました。',
       });
     });
   });

--- a/src/app/(main)/temp-passwords/_components/PreregistedPasswordList.tsx
+++ b/src/app/(main)/temp-passwords/_components/PreregistedPasswordList.tsx
@@ -16,8 +16,8 @@ const PreregistedPasswordList: React.FC<PreregistedPasswordListProps> = ({
   errorMessage,
 }) => {
   return (
-    <main className="flex-1 p-6" role="main">
-      <div className="flex justify-between items-center mb-8">
+    <main className="flex-1 p-4 md:p-6" role="main">
+      <div className="mb-6 flex flex-col gap-4 md:mb-8 md:flex-row md:items-center md:justify-between [&_h2]:mb-0">
         <Title title={title} />
       </div>
 

--- a/src/app/(main)/temp-passwords/_components/PreregistedPasswordTable.tsx
+++ b/src/app/(main)/temp-passwords/_components/PreregistedPasswordTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Th, TableRowWrapper } from '@/components/table';
+import MobileEmptyState from '@/components/MobileEmptyState';
 import { PreregistedPasswordIndexRow } from '@/api/services/preregistedPassword/preregistedPasswordService';
 import PreregistedPasswordTr from './PreregistedPasswordTr';
 
@@ -18,9 +19,7 @@ const PreregistedPasswordTable: React.FC<PreregistedPasswordTableProps> = ({
     <>
       <div className="space-y-4 md:hidden">
         {rows.length === 0 ? (
-          <div className="rounded-md border border-[#D9D9D9] bg-white px-4 py-6 text-center text-gray-600 shadow-[8px_8px_0_rgba(0,0,0,0.18)]">
-            {emptyMessage}
-          </div>
+          <MobileEmptyState message={emptyMessage} />
         ) : (
           rows.map((row) => (
             <PreregistedPasswordTr key={`${row.uuid}-card`} row={row} variant="card" />

--- a/src/app/(main)/temp-passwords/_components/PreregistedPasswordTable.tsx
+++ b/src/app/(main)/temp-passwords/_components/PreregistedPasswordTable.tsx
@@ -15,38 +15,54 @@ const PreregistedPasswordTable: React.FC<PreregistedPasswordTableProps> = ({
   const headerStyle = { backgroundColor: '#3E3E3E', borderColor: '#3E3E3E' };
 
   return (
-    <div className="bg-white shadow overflow-hidden">
-      <table className="w-full" role="table" aria-label="仮登録パスワード一覧">
-        <thead>
-          <TableRowWrapper className="text-white">
-            <Th className="border-r w-[130px]" style={headerStyle}>
-              登録日
-            </Th>
-            <Th className="border-r" style={headerStyle}>
-              アプリケーション名
-            </Th>
-            <Th className="border-r" style={headerStyle}>
-              アカウント名
-            </Th>
-            <Th className="w-[220px]" style={headerStyle}>
-              {''}
-            </Th>
-          </TableRowWrapper>
-        </thead>
+    <>
+      <div className="space-y-4 md:hidden">
+        {rows.length === 0 ? (
+          <div className="rounded-md border border-[#D9D9D9] bg-white px-4 py-6 text-center text-gray-600 shadow-[8px_8px_0_rgba(0,0,0,0.18)]">
+            {emptyMessage}
+          </div>
+        ) : (
+          rows.map((row) => (
+            <PreregistedPasswordTr key={`${row.uuid}-card`} row={row} variant="card" />
+          ))
+        )}
+      </div>
 
-        <tbody className="divide-y divide-gray-200">
-          {rows.length === 0 ? (
-            <tr>
-              <td colSpan={4} className="px-6 py-6 text-center text-gray-600">
-                {emptyMessage}
-              </td>
-            </tr>
-          ) : (
-            rows.map((row) => <PreregistedPasswordTr key={row.uuid} row={row} />)
-          )}
-        </tbody>
-      </table>
-    </div>
+      <div className="hidden overflow-hidden bg-white shadow md:block">
+        <table className="w-full" role="table" aria-label="仮登録パスワード一覧">
+          <thead>
+            <TableRowWrapper className="text-white">
+              <Th className="border-r w-[130px]" style={headerStyle}>
+                登録日
+              </Th>
+              <Th className="border-r" style={headerStyle}>
+                アプリケーション名
+              </Th>
+              <Th className="border-r" style={headerStyle}>
+                アカウント名
+              </Th>
+              <Th className="w-[220px]" style={headerStyle}>
+                {''}
+              </Th>
+            </TableRowWrapper>
+          </thead>
+
+          <tbody className="divide-y divide-gray-200">
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-6 py-6 text-center text-gray-600">
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <PreregistedPasswordTr key={`${row.uuid}-table`} row={row} />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 };
 

--- a/src/app/(main)/temp-passwords/_components/PreregistedPasswordTr.tsx
+++ b/src/app/(main)/temp-passwords/_components/PreregistedPasswordTr.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { Td, TableRowWrapper } from '@/components/table';
 import Button from '@/components/Button';
@@ -7,14 +8,49 @@ import { formatListDate } from '@/lib/dateFormat';
 
 type PreregistedPasswordTrProps = {
   row: PreregistedPasswordIndexRow;
+  variant?: 'table' | 'card';
 };
 
-const PreregistedPasswordTr: React.FC<PreregistedPasswordTrProps> = ({ row }) => {
+const PreregistedPasswordTr: React.FC<PreregistedPasswordTrProps> = ({
+  row,
+  variant = 'table',
+}) => {
   const borderStyle = { borderColor: '#d1d5db' };
   const handleDetailClick = async () => {
     'use server';
     redirect(`/temp-passwords/${encodeURIComponent(row.uuid)}`);
   };
+
+  if (variant === 'card') {
+    return (
+      <Link
+        href={`/temp-passwords/${encodeURIComponent(row.uuid)}`}
+        className="flex min-h-[150px] w-full max-w-[335px] items-center rounded-md border border-[#334155] bg-white p-4 text-left shadow-[8px_8px_0_rgba(0,0,0,0.18)] transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+      >
+        <dl className="w-full text-gray-900">
+          <div className="space-y-1">
+            <dd className="text-[15px] font-normal text-gray-900">
+              {`登録日: ${formatListDate(row.created_at)}`}
+            </dd>
+          </div>
+          <div
+            className="mb-3 mt-[3px] h-px w-full bg-[#334155]"
+            aria-hidden="true"
+          />
+          <div className="space-y-2">
+            <dd className="break-all text-[16px] font-semibold leading-6">
+              {`アプリケーション名: ${row.application_name}`}
+            </dd>
+          </div>
+          <div className="mt-2 space-y-2">
+            <dd className="break-all text-[16px] font-semibold leading-6">
+              {`アカウント名: ${row.account_name}`}
+            </dd>
+          </div>
+        </dl>
+      </Link>
+    );
+  }
 
   return (
     <TableRowWrapper>

--- a/src/app/(main)/temp-passwords/_components/PreregistedPasswordTr.tsx
+++ b/src/app/(main)/temp-passwords/_components/PreregistedPasswordTr.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { Td, TableRowWrapper } from '@/components/table';
 import Button from '@/components/Button';
+import MobileInfoCard from '@/components/MobileInfoCard';
 import { PreregistedPasswordIndexRow } from '@/api/services/preregistedPassword/preregistedPasswordService';
 import { formatListDate } from '@/lib/dateFormat';
 
@@ -23,32 +23,13 @@ const PreregistedPasswordTr: React.FC<PreregistedPasswordTrProps> = ({
 
   if (variant === 'card') {
     return (
-      <Link
+      <MobileInfoCard
         href={`/temp-passwords/${encodeURIComponent(row.uuid)}`}
-        className="flex min-h-[150px] w-full max-w-[335px] items-center rounded-md border border-[#334155] bg-white p-4 text-left shadow-[8px_8px_0_rgba(0,0,0,0.18)] transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
-      >
-        <dl className="w-full text-gray-900">
-          <div className="space-y-1">
-            <dd className="text-[15px] font-normal text-gray-900">
-              {`登録日: ${formatListDate(row.created_at)}`}
-            </dd>
-          </div>
-          <div
-            className="mb-3 mt-[3px] h-px w-full bg-[#334155]"
-            aria-hidden="true"
-          />
-          <div className="space-y-2">
-            <dd className="break-all text-[16px] font-semibold leading-6">
-              {`アプリケーション名: ${row.application_name}`}
-            </dd>
-          </div>
-          <div className="mt-2 space-y-2">
-            <dd className="break-all text-[16px] font-semibold leading-6">
-              {`アカウント名: ${row.account_name}`}
-            </dd>
-          </div>
-        </dl>
-      </Link>
+        headerText={`登録日: ${formatListDate(row.created_at)}`}
+        primaryText={`アプリケーション名: ${row.application_name}`}
+        secondaryText={`アカウント名: ${row.account_name}`}
+        centerContent
+      />
     );
   }
 

--- a/src/app/(main)/temp-passwords/_components/__tests__/PreregistedPasswordTr.test.tsx
+++ b/src/app/(main)/temp-passwords/_components/__tests__/PreregistedPasswordTr.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PreregistedPasswordTr from '../PreregistedPasswordTr';
+
+describe('PreregistedPasswordTr', () => {
+  const row = {
+    uuid: 'pre-uuid',
+    created_at: '2026-02-28T12:00:00+09:00',
+    application_name: 'GitHub',
+    account_name: 'octocat',
+  };
+
+  it('カード表示で必要な情報を表示する', () => {
+    render(<PreregistedPasswordTr row={row} variant="card" />);
+
+    expect(screen.getByText('登録日: 2026-02-28')).toBeInTheDocument();
+    expect(
+      screen.getByText('アプリケーション名: GitHub')
+    ).toBeInTheDocument();
+    expect(screen.getByText('アカウント名: octocat')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/temp-passwords/pre-uuid'
+    );
+  });
+});

--- a/src/app/_components/ErrorIcons.tsx
+++ b/src/app/_components/ErrorIcons.tsx
@@ -29,7 +29,7 @@ export function ServerErrorIcon(props: SVGProps<SVGSVGElement>) {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <g clip-path="url(#clip0_179_678)">
+      <g clipPath="url(#clip0_179_678)">
         <mask
           id="mask0_179_678"
           style={{ maskType: 'alpha' }}

--- a/src/components/MobileEmptyState.tsx
+++ b/src/components/MobileEmptyState.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+type MobileEmptyStateProps = {
+  message: string;
+};
+
+const MobileEmptyState: React.FC<MobileEmptyStateProps> = ({ message }) => {
+  return <p className="py-6 text-center text-sm text-gray-600">{message}</p>;
+};
+
+export default MobileEmptyState;

--- a/src/components/MobileInfoCard.tsx
+++ b/src/components/MobileInfoCard.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import Link from 'next/link';
+import React from 'react';
+
+type MobileInfoCardBaseProps = {
+  headerText: string;
+  primaryText: string;
+  secondaryText: string;
+  statusText?: string;
+  centerContent?: boolean;
+};
+
+type MobileInfoCardButtonProps = MobileInfoCardBaseProps & {
+  onClick: () => void;
+  disabled?: boolean;
+  href?: never;
+};
+
+type MobileInfoCardLinkProps = MobileInfoCardBaseProps & {
+  href: string;
+  onClick?: never;
+  disabled?: never;
+};
+
+type MobileInfoCardStaticProps = MobileInfoCardBaseProps & {
+  href?: never;
+  onClick?: never;
+  disabled?: never;
+};
+
+type MobileInfoCardProps =
+  | MobileInfoCardButtonProps
+  | MobileInfoCardLinkProps
+  | MobileInfoCardStaticProps;
+
+const containerClassName =
+  'min-h-[150px] w-full max-w-[335px] rounded-md border border-[#334155] bg-white p-4 text-left shadow-[8px_8px_0_rgba(0,0,0,0.18)]';
+
+const MobileInfoCardBody: React.FC<MobileInfoCardBaseProps> = ({
+  headerText,
+  primaryText,
+  secondaryText,
+  statusText,
+}) => {
+  return (
+    <>
+      <dl className="w-full text-gray-900">
+        <div className="space-y-1">
+          <dd className="text-[15px] font-normal text-gray-900">{headerText}</dd>
+        </div>
+        <div
+          className="mb-3 mt-[3px] h-px w-full bg-[#334155]"
+          aria-hidden="true"
+        />
+        <div className="space-y-2">
+          <dd className="break-all text-[16px] font-semibold leading-6">
+            {primaryText}
+          </dd>
+        </div>
+        <div className="mt-2 space-y-2">
+          <dd className="break-all text-[16px] font-semibold leading-6">
+            {secondaryText}
+          </dd>
+        </div>
+      </dl>
+      {statusText && (
+        <p className="mt-4 text-sm font-medium text-[#3CB371]">{statusText}</p>
+      )}
+    </>
+  );
+};
+
+const MobileInfoCard: React.FC<MobileInfoCardProps> = (props) => {
+  const alignClassName = props.centerContent ? 'flex items-center' : 'block';
+
+  if ('href' in props && props.href) {
+    return (
+      <Link
+        href={props.href}
+        className={`${alignClassName} ${containerClassName} transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2`}
+      >
+        <MobileInfoCardBody {...props} />
+      </Link>
+    );
+  }
+
+  if ('onClick' in props && props.onClick) {
+    return (
+      <button
+        type="button"
+        onClick={props.onClick}
+        disabled={props.disabled}
+        className={`${alignClassName} ${containerClassName} transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60`}
+      >
+        <MobileInfoCardBody {...props} />
+      </button>
+    );
+  }
+
+  return (
+    <div className={`${alignClassName} ${containerClassName}`}>
+      <MobileInfoCardBody {...props} />
+    </div>
+  );
+};
+
+export default MobileInfoCard;


### PR DESCRIPTION
## What changed
- added mobile card layouts for `/passwords` and `/temp-passwords` while keeping the existing desktop table layouts
- updated the password search mobile card to use full-card tap for password retrieval and adjusted the typography and divider styling
- updated the temporary password list mobile card to use full-card tap for detail navigation
- extracted shared mobile UI pieces into `MobileInfoCard` and `MobileEmptyState`
- fixed the React SVG attribute warning in `ErrorIcons`

## Why
- issue #111 requires mobile layouts for the password management and temporary password list screens without changing the PC layout
- the two mobile card UIs shared the same structure, so extracting the common pieces reduces duplication and makes future adjustments safer

## Impact
- mobile users now see card-based layouts on both list screens
- desktop users keep the existing table layouts
- empty states on mobile are now rendered as simple text instead of cards

## Validation
- `npx jest --runTestsByPath 'src/app/(main)/passwords/_components/__tests__/PasswordList.test.tsx'`
- `npx jest --runTestsByPath 'src/app/(main)/passwords/_components/__tests__/PasswordTr.test.tsx'`
- `npx jest --runTestsByPath 'src/app/(main)/temp-passwords/_components/__tests__/PreregistedPasswordTr.test.tsx'`
- `npx jest --runTestsByPath 'src/app/(main)/temp-passwords/[uuid]/_components/__tests__/PreregistedPasswordDetailView.test.tsx'`