### PR TITLE
#114 ログイン後のトップページ遷移をロール別URLに対応

### DIFF
--- a/src/api/services/auth/__tests__/authService.test.ts
+++ b/src/api/services/auth/__tests__/authService.test.ts
@@ -1,0 +1,29 @@
+import { extractTopPageUrl } from '../authService';
+
+describe('extractTopPageUrl', () => {
+  it('top_page_url をそのまま返す', () => {
+    expect(
+      extractTopPageUrl({
+        top_page_url: '/accounts',
+      })
+    ).toBe('/accounts');
+  });
+
+  it('data 配下にある top_page_url も取り出せる', () => {
+    expect(
+      extractTopPageUrl({
+        data: {
+          top_page_url: '/passwords',
+        },
+      })
+    ).toBe('/passwords');
+  });
+
+  it('アプリ内パスでない値は無視する', () => {
+    expect(
+      extractTopPageUrl({
+        top_page_url: 'https://example.com',
+      })
+    ).toBeNull();
+  });
+});

--- a/src/api/services/auth/authService.ts
+++ b/src/api/services/auth/authService.ts
@@ -11,10 +11,12 @@ export interface LoginRequest {
 export interface LoginResponse {
   access_token?: string;
   token?: string;
+  top_page_url?: string;
 }
 
 export interface LoginStatusResponse {
   name: string;
+  top_page_url?: string;
 }
 
 export interface LoginValidationError {
@@ -86,6 +88,24 @@ export const extractUserName = (value: unknown): string | null => {
   }
 
   return extractUserName(obj.data);
+};
+
+export const extractTopPageUrl = (value: unknown): string | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const candidates = [obj.top_page_url, obj.topPageUrl, obj.top_page_path];
+  const found = candidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.startsWith('/')
+  );
+  if (found) {
+    return found;
+  }
+
+  return extractTopPageUrl(obj.data);
 };
 
 const decodeBase64Url = (value: string): string | null => {

--- a/src/app/login/loginActions.ts
+++ b/src/app/login/loginActions.ts
@@ -13,6 +13,7 @@ export interface LoginFormState {
   message?: string; // Optional: General message for non-field specific errors
   shouldRedirect?: boolean;
   accessToken?: string;
+  topPageUrl?: string;
 }
 
 export async function loginAction(
@@ -59,6 +60,7 @@ export async function loginAction(
         message: 'Login successful.',
         shouldRedirect: true, // 成功時にリダイレクトフラグを立てる
         accessToken,
+        topPageUrl: response.data?.top_page_url,
       };
     }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { apiClient } from '@/api';
 import {
   AuthService,
+  extractTopPageUrl,
   extractUserName,
   extractUserNameFromToken,
 } from '@/api/services/auth/authService';
@@ -43,12 +44,17 @@ const LoginForm: React.FC = () => {
         localStorage.setItem('auth_user_name', userName);
       }
 
+      const redirectTo =
+        state.topPageUrl ||
+        (response.success ? extractTopPageUrl(response.data) : null) ||
+        '/login';
+
       window.dispatchEvent(new Event('auth-token-updated'));
-      router.push('/applications');
+      router.push(redirectTo);
     };
 
     void handleLoginSuccess();
-  }, [state.shouldRedirect, state.accessToken, router]);
+  }, [state.shouldRedirect, state.accessToken, state.topPageUrl, router]);
 
   return (
     <div className="min-h-screen w-full flex items-center justify-center p-4 bg-[#f0f0f0]">


### PR DESCRIPTION
## 概要
- ログイン API / login status の `top_page_url` をフロントで扱えるように変更
- ログイン成功後の遷移先を固定の `/applications` から `top_page_url` ベースへ変更
- `top_page_url` が未指定の場合は `/login` にフォールバック

## 背景
- Issue #114 では、ログインユーザーのロールに応じてトップページを切り替える必要がある
- バックエンド側で `top_page_url` が返るようになったため、フロントでもその値を利用する必要があった

## 変更内容
- `AuthService` のログイン関連レスポンス型へ `top_page_url` を追加
- `top_page_url` 抽出ヘルパーを追加し、レスポンスの入れ子構造にも対応
- `loginAction` で `top_page_url` をクライアント側 state へ引き渡し
- ログイン画面で `top_page_url` を優先して遷移先を決定
- `top_page_url` 抽出ロジックのユニットテストを追加

## 影響
- ロールごとに異なるトップページへ遷移できるようになる
- バックエンドが `top_page_url` を返さない場合はログイン画面に留まる

## 確認
- `npm test -- --runInBand src/api/services/auth/__tests__/authService.test.ts`
- `npm test -- --runInBand --runTestsByPath 'src/app/(main)/__tests__/AuthSessionGuard.test.tsx'`