### PR TITLE
#116 Add role-based page authorization guards

### DIFF
--- a/src/api/services/auth/__tests__/authService.test.ts
+++ b/src/api/services/auth/__tests__/authService.test.ts
@@ -1,8 +1,4 @@
-import {
-  extractTopPageUrl,
-  extractUserRole,
-  extractUserRoleFromToken,
-} from '../authService';
+import { extractTopPageUrl, extractUserRole } from '../authService';
 
 describe('extractTopPageUrl', () => {
   it('top_page_url をそのまま返す', () => {
@@ -43,38 +39,21 @@ describe('extractUserRole', () => {
     ).toBe('admin');
   });
 
-  it('data 配下の role.code から WEB 一般ユーザーロールを取り出せる', () => {
+  it('WEB 一般ユーザーロールを取り出せる', () => {
     expect(
       extractUserRole({
-        data: {
-          role: {
-            code: 'WEB_USER',
-          },
+        role: {
+          code: 'WEB_USER',
         },
       })
     ).toBe('general');
   });
 
-  it('トップページ URL からモバイルユーザーロールを補完できる', () => {
+  it('未知の形式は null を返す', () => {
     expect(
       extractUserRole({
-        top_page_url: '/temp-passwords',
+        role: null,
       })
-    ).toBe('mobile');
-  });
-});
-
-describe('extractUserRoleFromToken', () => {
-  it('JWT の payload からロールを取り出せる', () => {
-    const payload = Buffer.from(
-      JSON.stringify({ user: { role: { code: 'MOBILE_USER' } } })
-    )
-      .toString('base64')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/g, '');
-    const token = `header.${payload}.signature`;
-
-    expect(extractUserRoleFromToken(token)).toBe('mobile');
+    ).toBeNull();
   });
 });

--- a/src/api/services/auth/__tests__/authService.test.ts
+++ b/src/api/services/auth/__tests__/authService.test.ts
@@ -1,4 +1,8 @@
-import { extractTopPageUrl } from '../authService';
+import {
+  extractTopPageUrl,
+  extractUserRole,
+  extractUserRoleFromToken,
+} from '../authService';
 
 describe('extractTopPageUrl', () => {
   it('top_page_url をそのまま返す', () => {
@@ -25,5 +29,52 @@ describe('extractTopPageUrl', () => {
         top_page_url: 'https://example.com',
       })
     ).toBeNull();
+  });
+});
+
+describe('extractUserRole', () => {
+  it('role.code から管理者ロールを取り出せる', () => {
+    expect(
+      extractUserRole({
+        role: {
+          code: 'ADMIN',
+        },
+      })
+    ).toBe('admin');
+  });
+
+  it('data 配下の role.code から WEB 一般ユーザーロールを取り出せる', () => {
+    expect(
+      extractUserRole({
+        data: {
+          role: {
+            code: 'WEB_USER',
+          },
+        },
+      })
+    ).toBe('general');
+  });
+
+  it('トップページ URL からモバイルユーザーロールを補完できる', () => {
+    expect(
+      extractUserRole({
+        top_page_url: '/temp-passwords',
+      })
+    ).toBe('mobile');
+  });
+});
+
+describe('extractUserRoleFromToken', () => {
+  it('JWT の payload からロールを取り出せる', () => {
+    const payload = Buffer.from(
+      JSON.stringify({ user: { role: { code: 'MOBILE_USER' } } })
+    )
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+    const token = `header.${payload}.signature`;
+
+    expect(extractUserRoleFromToken(token)).toBe('mobile');
   });
 });

--- a/src/api/services/auth/authService.ts
+++ b/src/api/services/auth/authService.ts
@@ -1,5 +1,5 @@
 import apiClient from '../../client';
-import { ApiResponse } from '../../types';
+import { ApiResponse, RequestConfig } from '../../types';
 import { extractValidationErrors } from '../../utils/validationErrorTransformer';
 
 export interface LoginRequest {
@@ -17,7 +17,12 @@ export interface LoginResponse {
 export interface LoginStatusResponse {
   name: string;
   top_page_url?: string;
+  role?: {
+    code: string;
+  } | null;
 }
+
+export type AppUserRole = 'admin' | 'general' | 'mobile';
 
 export interface LoginValidationError {
   email?: string[];
@@ -46,14 +51,103 @@ export class AuthService {
     return response as ApiResponse<LoginResponse>;
   }
 
-  static async loginStatus(): Promise<ApiResponse<LoginStatusResponse>> {
-    return apiClient.get<LoginStatusResponse>('/login/status');
+  static async loginStatus(
+    config?: RequestConfig
+  ): Promise<ApiResponse<LoginStatusResponse>> {
+    return apiClient.get<LoginStatusResponse>('/login/status', config);
   }
 
   static async logout(): Promise<ApiResponse<void>> {
     return apiClient.post<void>('/logout');
   }
 }
+
+const ROLE_PATTERNS: Array<{
+  role: AppUserRole;
+  patterns: RegExp[];
+}> = [
+  {
+    role: 'admin',
+    patterns: [/^admin$/, /^administrator$/, /^システム管理者$/],
+  },
+  {
+    role: 'general',
+    patterns: [/^web_user$/, /^general$/, /^general[_\s-]?user$/, /^web一般ユーザー$/],
+  },
+  {
+    role: 'mobile',
+    patterns: [/^mobile_user$/, /^mobile$/, /^mobile[_\s-]?user$/, /^mobile一般ユーザー$/],
+  },
+];
+
+const normalizeRoleText = (value: string): string =>
+  value.trim().toLowerCase().replace(/\s+/g, '_');
+
+const extractRoleFromTopPageUrl = (value: unknown): AppUserRole | null => {
+  const topPageUrl = extractTopPageUrl(value);
+
+  if (topPageUrl === '/applications' || topPageUrl === '/accounts') {
+    return 'admin';
+  }
+
+  if (topPageUrl === '/unregisted-passwords') {
+    return 'general';
+  }
+
+  if (topPageUrl === '/temp-passwords') {
+    return 'mobile';
+  }
+
+  return null;
+};
+
+export const normalizeUserRole = (value: unknown): AppUserRole | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = normalizeRoleText(value);
+  const matchedRole = ROLE_PATTERNS.find(({ patterns }) =>
+    patterns.some((pattern) => pattern.test(normalized))
+  );
+
+  return matchedRole?.role ?? null;
+};
+
+export const extractUserRole = (value: unknown): AppUserRole | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const roleCandidates = [
+    typeof obj.role === 'object' && obj.role !== null
+      ? (obj.role as Record<string, unknown>).code
+      : obj.role,
+    obj.role_name,
+    obj.roleName,
+    obj.user_role,
+    obj.userRole,
+  ];
+
+  const resolvedRole = roleCandidates
+    .map((candidate) => normalizeUserRole(candidate))
+    .find((candidate): candidate is AppUserRole => candidate !== null);
+
+  if (resolvedRole) {
+    return resolvedRole;
+  }
+
+  const nestedCandidates = [obj.user, obj.account, obj.data];
+  for (const nestedCandidate of nestedCandidates) {
+    const nestedRole = extractUserRole(nestedCandidate);
+    if (nestedRole) {
+      return nestedRole;
+    }
+  }
+
+  return extractRoleFromTopPageUrl(obj);
+};
 
 export const extractUserName = (value: unknown): string | null => {
   if (!value || typeof value !== 'object') {
@@ -158,6 +252,29 @@ export const extractUserNameFromToken = (token: string): string | null => {
         typeof candidate === 'string' && candidate.trim().length > 0
     );
     return fallback ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export const extractUserRoleFromToken = (token: string): AppUserRole | null => {
+  if (!token) {
+    return null;
+  }
+
+  const parts = token.split('.');
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const payloadText = decodeBase64Url(parts[1]);
+  if (!payloadText) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(payloadText) as Record<string, unknown>;
+    return extractUserRole(payload);
   } catch {
     return null;
   }

--- a/src/api/services/auth/authService.ts
+++ b/src/api/services/auth/authService.ts
@@ -83,25 +83,7 @@ const ROLE_PATTERNS: Array<{
 const normalizeRoleText = (value: string): string =>
   value.trim().toLowerCase().replace(/\s+/g, '_');
 
-const extractRoleFromTopPageUrl = (value: unknown): AppUserRole | null => {
-  const topPageUrl = extractTopPageUrl(value);
-
-  if (topPageUrl === '/applications' || topPageUrl === '/accounts') {
-    return 'admin';
-  }
-
-  if (topPageUrl === '/unregisted-passwords') {
-    return 'general';
-  }
-
-  if (topPageUrl === '/temp-passwords') {
-    return 'mobile';
-  }
-
-  return null;
-};
-
-export const normalizeUserRole = (value: unknown): AppUserRole | null => {
+const normalizeUserRole = (value: unknown): AppUserRole | null => {
   if (typeof value !== 'string') {
     return null;
   }
@@ -120,33 +102,12 @@ export const extractUserRole = (value: unknown): AppUserRole | null => {
   }
 
   const obj = value as Record<string, unknown>;
-  const roleCandidates = [
+  const roleCode =
     typeof obj.role === 'object' && obj.role !== null
       ? (obj.role as Record<string, unknown>).code
-      : obj.role,
-    obj.role_name,
-    obj.roleName,
-    obj.user_role,
-    obj.userRole,
-  ];
+      : undefined;
 
-  const resolvedRole = roleCandidates
-    .map((candidate) => normalizeUserRole(candidate))
-    .find((candidate): candidate is AppUserRole => candidate !== null);
-
-  if (resolvedRole) {
-    return resolvedRole;
-  }
-
-  const nestedCandidates = [obj.user, obj.account, obj.data];
-  for (const nestedCandidate of nestedCandidates) {
-    const nestedRole = extractUserRole(nestedCandidate);
-    if (nestedRole) {
-      return nestedRole;
-    }
-  }
-
-  return extractRoleFromTopPageUrl(obj);
+  return normalizeUserRole(roleCode);
 };
 
 export const extractUserName = (value: unknown): string | null => {
@@ -252,29 +213,6 @@ export const extractUserNameFromToken = (token: string): string | null => {
         typeof candidate === 'string' && candidate.trim().length > 0
     );
     return fallback ?? null;
-  } catch {
-    return null;
-  }
-};
-
-export const extractUserRoleFromToken = (token: string): AppUserRole | null => {
-  if (!token) {
-    return null;
-  }
-
-  const parts = token.split('.');
-  if (parts.length < 2) {
-    return null;
-  }
-
-  const payloadText = decodeBase64Url(parts[1]);
-  if (!payloadText) {
-    return null;
-  }
-
-  try {
-    const payload = JSON.parse(payloadText) as Record<string, unknown>;
-    return extractUserRole(payload);
   } catch {
     return null;
   }

--- a/src/app/(main)/AuthSessionGuard.tsx
+++ b/src/app/(main)/AuthSessionGuard.tsx
@@ -6,6 +6,7 @@ import { apiClient } from '@/api';
 import { AuthService } from '@/api/services/auth/authService';
 
 const LOGIN_PATH = '/login';
+const SESSION_POLL_INTERVAL_MS = 60_000;
 
 const hasAuthTokenCookie = () => {
   if (typeof document === 'undefined') {
@@ -82,7 +83,7 @@ export default function AuthSessionGuard() {
     document.addEventListener('visibilitychange', handleAuthTokenUpdated);
     const intervalId = window.setInterval(() => {
       void validateSession();
-    }, 1000);
+    }, SESSION_POLL_INTERVAL_MS);
 
     return () => {
       ignore = true;

--- a/src/app/(main)/accounts/layout.tsx
+++ b/src/app/(main)/accounts/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+type AccountsLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function AccountsLayout({ children }: AccountsLayoutProps) {
+  await authorizePageAccess([APP_USER_ROLES.admin]);
+
+  return <>{children}</>;
+}

--- a/src/app/(main)/applications/layout.tsx
+++ b/src/app/(main)/applications/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+type ApplicationsLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function ApplicationsLayout({
+  children,
+}: ApplicationsLayoutProps) {
+  await authorizePageAccess([APP_USER_ROLES.admin]);
+
+  return <>{children}</>;
+}

--- a/src/app/(main)/passwords/layout.tsx
+++ b/src/app/(main)/passwords/layout.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+type PasswordsLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function PasswordsLayout({
+  children,
+}: PasswordsLayoutProps) {
+  await authorizePageAccess([
+    APP_USER_ROLES.admin,
+    APP_USER_ROLES.general,
+    APP_USER_ROLES.mobile,
+  ]);
+
+  return <>{children}</>;
+}

--- a/src/app/(main)/temp-passwords/layout.tsx
+++ b/src/app/(main)/temp-passwords/layout.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+type TempPasswordsLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function TempPasswordsLayout({
+  children,
+}: TempPasswordsLayoutProps) {
+  await authorizePageAccess([
+    APP_USER_ROLES.admin,
+    APP_USER_ROLES.general,
+    APP_USER_ROLES.mobile,
+  ]);
+
+  return <>{children}</>;
+}

--- a/src/app/(main)/unregisted-passwords/layout.tsx
+++ b/src/app/(main)/unregisted-passwords/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+type UnregistedPasswordsLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function UnregistedPasswordsLayout({
+  children,
+}: UnregistedPasswordsLayoutProps) {
+  await authorizePageAccess([APP_USER_ROLES.admin, APP_USER_ROLES.general]);
+
+  return <>{children}</>;
+}

--- a/src/lib/__tests__/authorization.test.ts
+++ b/src/lib/__tests__/authorization.test.ts
@@ -24,11 +24,11 @@ jest.mock('@/api/services/auth/authService', () => ({
     if (roleCode === 'WEB_USER') {
       return 'general';
     }
+    if (roleCode === 'MOBILE_USER') {
+      return 'mobile';
+    }
     return null;
   }),
-  extractUserRoleFromToken: jest.fn((token: string) =>
-    token === 'mobile-token' ? 'mobile' : null
-  ),
 }));
 
 jest.mock('../serverAuthConfig', () => ({
@@ -85,12 +85,23 @@ describe('authorizePageAccess', () => {
     expect(notFound).toHaveBeenCalled();
   });
 
-  it('login status にロールが無い場合はトークンをフォールバックで使う', async () => {
+  it('login status が 500 の場合も 404 にする', async () => {
+    mockLoginStatus.mockResolvedValue({
+      success: false,
+      error: { message: 'server error', status: 500 },
+    });
+
+    await expect(
+      authorizePageAccess([APP_USER_ROLES.admin])
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('許可されたモバイルロールなら通す', async () => {
     mockLoginStatus.mockResolvedValue({
       success: true,
-      data: { name: 'tester' },
+      data: { name: 'tester', role: { code: 'MOBILE_USER' } },
     });
-    mockGetServerAuthToken.mockResolvedValue('mobile-token');
 
     await expect(
       authorizePageAccess([APP_USER_ROLES.mobile])

--- a/src/lib/__tests__/authorization.test.ts
+++ b/src/lib/__tests__/authorization.test.ts
@@ -1,0 +1,99 @@
+import { notFound } from 'next/navigation';
+import { authorizePageAccess, APP_USER_ROLES } from '../authorization';
+import { AuthService } from '@/api/services/auth/authService';
+import { getServerAuthConfig, getServerAuthToken } from '../serverAuthConfig';
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+  redirect: jest.fn(() => {
+    throw new Error('NEXT_REDIRECT');
+  }),
+}));
+
+jest.mock('@/api/services/auth/authService', () => ({
+  AuthService: {
+    loginStatus: jest.fn(),
+  },
+  extractUserRole: jest.fn((value: unknown) => {
+    const roleCode = (value as { role?: { code?: string } | null } | undefined)?.role?.code;
+    if (roleCode === 'ADMIN') {
+      return 'admin';
+    }
+    if (roleCode === 'WEB_USER') {
+      return 'general';
+    }
+    return null;
+  }),
+  extractUserRoleFromToken: jest.fn((token: string) =>
+    token === 'mobile-token' ? 'mobile' : null
+  ),
+}));
+
+jest.mock('../serverAuthConfig', () => ({
+  getServerAuthConfig: jest.fn(),
+  getServerAuthToken: jest.fn(),
+}));
+
+describe('authorizePageAccess', () => {
+  const mockLoginStatus =
+    AuthService.loginStatus as jest.MockedFunction<typeof AuthService.loginStatus>;
+  const mockGetServerAuthConfig =
+    getServerAuthConfig as jest.MockedFunction<typeof getServerAuthConfig>;
+  const mockGetServerAuthToken =
+    getServerAuthToken as jest.MockedFunction<typeof getServerAuthToken>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerAuthConfig.mockResolvedValue({
+      headers: {
+        Authorization: 'Bearer token',
+      },
+    });
+    mockGetServerAuthToken.mockResolvedValue('token');
+  });
+
+  it('認証トークンが無ければログインへ遷移する', async () => {
+    mockGetServerAuthToken.mockResolvedValue(null);
+
+    await expect(
+      authorizePageAccess([APP_USER_ROLES.admin])
+    ).rejects.toThrow('NEXT_REDIRECT');
+  });
+
+  it('許可ロールなら何もしない', async () => {
+    mockLoginStatus.mockResolvedValue({
+      success: true,
+      data: { name: 'tester', role: { code: 'ADMIN' } },
+    });
+
+    await expect(
+      authorizePageAccess([APP_USER_ROLES.admin])
+    ).resolves.toBeUndefined();
+  });
+
+  it('未許可ロールなら 404 にする', async () => {
+    mockLoginStatus.mockResolvedValue({
+      success: true,
+      data: { name: 'tester', role: { code: 'WEB_USER' } },
+    });
+
+    await expect(
+      authorizePageAccess([APP_USER_ROLES.admin])
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('login status にロールが無い場合はトークンをフォールバックで使う', async () => {
+    mockLoginStatus.mockResolvedValue({
+      success: true,
+      data: { name: 'tester' },
+    });
+    mockGetServerAuthToken.mockResolvedValue('mobile-token');
+
+    await expect(
+      authorizePageAccess([APP_USER_ROLES.mobile])
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { notFound, redirect } from 'next/navigation';
+import {
+  AppUserRole,
+  AuthService,
+  extractUserRole,
+  extractUserRoleFromToken,
+} from '@/api/services/auth/authService';
+import { guardApiResponse } from '@/app/_lib/responseGuard';
+import { getServerAuthConfig, getServerAuthToken } from './serverAuthConfig';
+
+export const APP_USER_ROLES = {
+  admin: 'admin',
+  general: 'general',
+  mobile: 'mobile',
+} as const satisfies Record<string, AppUserRole>;
+
+export async function authorizePageAccess(
+  allowedRoles: readonly AppUserRole[]
+): Promise<void> {
+  const authToken = await getServerAuthToken();
+  if (!authToken) {
+    redirect('/login');
+  }
+
+  const authConfig = await getServerAuthConfig();
+  const response = guardApiResponse(await AuthService.loginStatus(authConfig));
+  const currentRole =
+    extractUserRole(response.data) ?? extractUserRoleFromToken(authToken ?? '');
+
+  if (!currentRole || !allowedRoles.includes(currentRole)) {
+    notFound();
+  }
+}

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -1,13 +1,7 @@
 import 'server-only';
 
 import { notFound, redirect } from 'next/navigation';
-import {
-  AppUserRole,
-  AuthService,
-  extractUserRole,
-  extractUserRoleFromToken,
-} from '@/api/services/auth/authService';
-import { guardApiResponse } from '@/app/_lib/responseGuard';
+import { AppUserRole, AuthService, extractUserRole } from '@/api/services/auth/authService';
 import { getServerAuthConfig, getServerAuthToken } from './serverAuthConfig';
 
 export const APP_USER_ROLES = {
@@ -25,9 +19,18 @@ export async function authorizePageAccess(
   }
 
   const authConfig = await getServerAuthConfig();
-  const response = guardApiResponse(await AuthService.loginStatus(authConfig));
-  const currentRole =
-    extractUserRole(response.data) ?? extractUserRoleFromToken(authToken ?? '');
+  const response = await AuthService.loginStatus(authConfig);
+  if (!response.success) {
+    const status = response.error?.status ?? 500;
+
+    if (status === 401 || status === 403) {
+      redirect('/login');
+    }
+
+    notFound();
+  }
+
+  const currentRole = extractUserRole(response.data);
 
   if (!currentRole || !allowedRoles.includes(currentRole)) {
     notFound();

--- a/src/lib/serverAuthConfig.ts
+++ b/src/lib/serverAuthConfig.ts
@@ -3,9 +3,13 @@ import 'server-only';
 import { cookies } from 'next/headers';
 import type { RequestConfig } from '@/api/types';
 
-export async function getServerAuthConfig(): Promise<RequestConfig> {
+export async function getServerAuthToken(): Promise<string | null> {
   const cookieStore = await cookies();
-  const token = cookieStore.get('auth_token')?.value;
+  return cookieStore.get('auth_token')?.value ?? null;
+}
+
+export async function getServerAuthConfig(): Promise<RequestConfig> {
+  const token = await getServerAuthToken();
 
   if (!token) {
     return {};


### PR DESCRIPTION
## Summary
- add a server-side authorization guard for page access by user role
- protect applications, accounts, unregistered passwords, passwords, and temp-passwords routes at the route layout level
- align login status role parsing with backend PR #144 by reading `role.code`

## Why
- Issue #116 requires route access control based on the logged-in user's role
- pages that are available to all authenticated roles still need auth enforcement, while unauthorized roles should receive 404 on restricted pages

## Impact
- admin-only routes now return 404 for non-admin users
- unregistered password routes now return 404 for `MOBILE_USER`
- passwords and temp-passwords routes now require authentication but remain accessible to all roles

## Validation
- `npm test -- --runInBand 'src/lib/__tests__/authorization.test.ts' 'src/api/services/auth/__tests__/authService.test.ts'`
- `npx tsc --noEmit`
- `npx eslint 'src/lib/authorization.ts' 'src/lib/__tests__/authorization.test.ts' 'src/app/(main)/temp-passwords/layout.tsx' 'src/app/(main)/passwords/layout.tsx'`

Closes #116