### PR TITLE
[codex] Hide password create button for mobile users

### DIFF
--- a/src/app/(main)/passwords/__tests__/page.test.tsx
+++ b/src/app/(main)/passwords/__tests__/page.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Page } from '../page';
+import { ApplicationService } from '@/api/services/application/applicationService';
+import { extractUserRole } from '@/api/services/auth/authService';
+import {
+  PasswordService,
+  extractPasswordIndexRows,
+} from '@/api/services/password/passwordService';
+import { guardApiResponse } from '@/app/_lib/responseGuard';
+import { getServerAuthConfig } from '@/lib/serverAuthConfig';
+import { AuthService } from '@/api/services/auth/authService';
+
+jest.mock('../_components/PasswordList', () => {
+  const react = require('react');
+  const MockPasswordList = (props: unknown) => react.createElement('div', props);
+
+  MockPasswordList.displayName = 'MockPasswordList';
+
+  return MockPasswordList;
+});
+
+jest.mock('@/api/services/application/applicationService', () => ({
+  ApplicationService: {
+    index: jest.fn(),
+  },
+}));
+
+jest.mock('@/api/services/password/passwordService', () => ({
+  PasswordService: {
+    index: jest.fn(),
+  },
+  extractPasswordIndexRows: jest.fn(),
+}));
+
+jest.mock('@/app/_lib/responseGuard', () => ({
+  guardApiResponse: jest.fn((value) => value),
+}));
+
+jest.mock('@/lib/serverAuthConfig', () => ({
+  getServerAuthConfig: jest.fn(),
+}));
+
+jest.mock('@/api/services/auth/authService', () => ({
+  AuthService: {
+    loginStatus: jest.fn(),
+  },
+  extractUserRole: jest.fn((value: unknown) => {
+    const roleCode = (value as { role?: { code?: string } | null } | undefined)?.role?.code;
+
+    if (roleCode === 'MOBILE_USER') {
+      return 'mobile';
+    }
+
+    if (roleCode === 'WEB_USER') {
+      return 'general';
+    }
+
+    if (roleCode === 'ADMIN') {
+      return 'admin';
+    }
+
+    return null;
+  }),
+}));
+
+describe('passwords page', () => {
+  const mockApplicationIndex =
+    ApplicationService.index as jest.MockedFunction<typeof ApplicationService.index>;
+  const mockExtractUserRole =
+    extractUserRole as jest.MockedFunction<typeof extractUserRole>;
+  const mockPasswordIndex =
+    PasswordService.index as jest.MockedFunction<typeof PasswordService.index>;
+  const mockExtractPasswordIndexRows =
+    extractPasswordIndexRows as jest.MockedFunction<typeof extractPasswordIndexRows>;
+  const mockGuardApiResponse =
+    guardApiResponse as jest.MockedFunction<typeof guardApiResponse>;
+  const mockGetServerAuthConfig =
+    getServerAuthConfig as jest.MockedFunction<typeof getServerAuthConfig>;
+  const mockLoginStatus =
+    AuthService.loginStatus as jest.MockedFunction<typeof AuthService.loginStatus>;
+
+  beforeEach(() => {
+    mockApplicationIndex.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    mockPasswordIndex.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    mockExtractPasswordIndexRows.mockReturnValue([]);
+    mockGuardApiResponse.mockImplementation((value) => value);
+    mockGetServerAuthConfig.mockResolvedValue({
+      headers: {
+        Authorization: 'Bearer token',
+      },
+    });
+    mockLoginStatus.mockResolvedValue({
+      success: true,
+      data: { name: 'tester', role: { code: 'WEB_USER' } },
+    });
+    mockExtractUserRole.mockReturnValue('general');
+  });
+
+  it('モバイルユーザーでは新規登録ボタンを非表示にする', async () => {
+    mockLoginStatus.mockResolvedValue({
+      success: true,
+      data: { name: 'tester', role: { code: 'MOBILE_USER' } },
+    });
+    mockExtractUserRole.mockReturnValue('mobile');
+
+    const result = await Page({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(React.isValidElement(result)).toBe(true);
+    expect(result.props).toEqual(
+      expect.objectContaining({
+        showCreateButton: false,
+      })
+    );
+  });
+});

--- a/src/app/(main)/passwords/_components/PasswordList.tsx
+++ b/src/app/(main)/passwords/_components/PasswordList.tsx
@@ -22,6 +22,7 @@ type PasswordListProps = {
   applications: PasswordApplicationOption[];
   selectedApplicationId?: string;
   errorMessage?: string;
+  showCreateButton?: boolean;
 };
 
 const PasswordList: React.FC<PasswordListProps> = ({
@@ -30,6 +31,7 @@ const PasswordList: React.FC<PasswordListProps> = ({
   applications,
   selectedApplicationId = '',
   errorMessage,
+  showCreateButton = true,
 }) => {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -61,9 +63,11 @@ const PasswordList: React.FC<PasswordListProps> = ({
     <main className="flex-1 p-4 md:p-6" role="main">
       <div className="mb-6 flex flex-col gap-4 md:mb-8 md:flex-row md:items-center md:justify-between [&_h2]:mb-0">
         <Title title={title} />
-        <div className="hidden w-full md:block md:w-auto">
-          <SubmitButton onClick={handleCreateClick} text="新規登録" />
-        </div>
+        {showCreateButton && (
+          <div className="hidden w-full md:block md:w-auto">
+            <SubmitButton onClick={handleCreateClick} text="新規登録" />
+          </div>
+        )}
       </div>
 
       {/* アプリケーション */}

--- a/src/app/(main)/passwords/_components/__tests__/PasswordList.test.tsx
+++ b/src/app/(main)/passwords/_components/__tests__/PasswordList.test.tsx
@@ -96,4 +96,19 @@ describe('PasswordList', () => {
       screen.getAllByText('パスワード一覧を表示できません。')
     ).not.toHaveLength(0);
   });
+
+  it('新規登録ボタンを非表示にできる', () => {
+    render(
+      <PasswordList
+        title="パスワード検索"
+        rows={[]}
+        applications={[]}
+        showCreateButton={false}
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: '新規登録' })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/app/(main)/passwords/page.tsx
+++ b/src/app/(main)/passwords/page.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import PasswordList from './_components/PasswordList';
 import { PasswordApplicationOption } from './types';
 import { ApplicationService } from '@/api/services/application/applicationService';
+import { AuthService, extractUserRole } from '@/api/services/auth/authService';
 import {
   extractPasswordIndexRows,
   PasswordService,
@@ -54,18 +55,21 @@ const parseApplicationId = (
   return Number.isInteger(parsedValue) ? parsedValue : undefined;
 };
 
-const Page: React.FC<PasswordPageProps> = async ({ searchParams }) => {
+export const Page: React.FC<PasswordPageProps> = async ({ searchParams }) => {
   const resolvedSearchParams = searchParams ? await searchParams : {};
   const selectedApplicationId = parseApplicationId(
     resolvedSearchParams.application_id
   );
   const authConfig = await getServerAuthConfig();
-  const [applicationsResponse, passwordsResponse] = await Promise.all([
+  const [applicationsResponse, passwordsResponse, loginStatusResponse] =
+    await Promise.all([
     ApplicationService.index(authConfig),
     PasswordService.index(selectedApplicationId ?? undefined, authConfig),
-  ]).then(([applications, passwords]) => [
+    AuthService.loginStatus(authConfig),
+  ]).then(([applications, passwords, loginStatus]) => [
     guardApiResponse(applications),
     guardApiResponse(passwords),
+    guardApiResponse(loginStatus),
   ]);
 
   const applications = applicationsResponse.success
@@ -74,12 +78,17 @@ const Page: React.FC<PasswordPageProps> = async ({ searchParams }) => {
   const rows = passwordsResponse.success
     ? extractPasswordIndexRows(passwordsResponse.data)
     : [];
+  const currentRole = loginStatusResponse.success
+    ? extractUserRole(loginStatusResponse.data)
+    : null;
+
   return (
     <PasswordList
       title="パスワード検索"
       rows={rows}
       applications={applications}
       selectedApplicationId={selectedApplicationId?.toString()}
+      showCreateButton={currentRole !== 'mobile'}
     />
   );
 };


### PR DESCRIPTION
## What changed
- hide the password search "新規登録" button for users with the `mobile` role
- fetch the current login role in the passwords page and pass a display flag into `PasswordList`
- add tests for both the page-level role handling and the component-level button visibility

## Why
Issue #118 requires mobile users to be unable to start password registration from the password search screen.

## Impact
- mobile users no longer see the desktop-only create entry point on the password search page
- admin and general users keep the existing behavior

## Root cause
The password search screen always rendered the create button and did not branch on the authenticated user's role.

## Validation
- `npm test -- --runInBand --testPathPatterns='src/app/.*/passwords/|src/api/services/auth/__tests__/authService.test.ts|src/lib/__tests__/authorization.test.ts'`