### PR TITLE
[codex] Restrict password create page for mobile users

### DIFF
--- a/src/app/(main)/passwords/create/__tests__/layout.test.tsx
+++ b/src/app/(main)/passwords/create/__tests__/layout.test.tsx
@@ -1,0 +1,32 @@
+import PasswordCreateLayout from '../layout';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+jest.mock('@/lib/authorization', () => ({
+  authorizePageAccess: jest.fn(),
+  APP_USER_ROLES: {
+    admin: 'admin',
+    general: 'general',
+    mobile: 'mobile',
+  },
+}));
+
+describe('passwords/create layout', () => {
+  const mockAuthorizePageAccess =
+    authorizePageAccess as jest.MockedFunction<typeof authorizePageAccess>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('モバイルユーザーを許可せず admin と general のみ通す', async () => {
+    const result = await PasswordCreateLayout({
+      children: <div>password create</div>,
+    });
+
+    expect(mockAuthorizePageAccess).toHaveBeenCalledWith([
+      APP_USER_ROLES.admin,
+      APP_USER_ROLES.general,
+    ]);
+    expect(result.props.children).toEqual(<div>password create</div>);
+  });
+});

--- a/src/app/(main)/passwords/create/layout.tsx
+++ b/src/app/(main)/passwords/create/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { authorizePageAccess, APP_USER_ROLES } from '@/lib/authorization';
+
+type PasswordCreateLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function PasswordCreateLayout({
+  children,
+}: PasswordCreateLayoutProps) {
+  await authorizePageAccess([APP_USER_ROLES.admin, APP_USER_ROLES.general]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## What changed
- added a dedicated layout for `passwords/create`
- restricted access on that route to `admin` and `general` roles only
- added a test to lock the route authorization behavior

## Why
Mobile users should not be able to access the password registration screen. The route previously inherited the broader `passwords` authorization and allowed the mobile role through.

## Impact
- mobile users now receive a 404 when accessing `/passwords/create`
- existing access for admin and general users is unchanged

## Validation
- `npm test -- --runInBand --runTestsByPath "src/app/(main)/passwords/create/__tests__/layout.test.tsx"`