### PR TITLE
ログイン画面でredirectクエリを処理

### DIFF
--- a/src/app/login/__tests__/redirect.test.ts
+++ b/src/app/login/__tests__/redirect.test.ts
@@ -1,0 +1,38 @@
+import { resolveLoginRedirectTarget } from '../redirect';
+
+describe('resolveLoginRedirectTarget', () => {
+  it('相対パスをそのまま返す', () => {
+    expect(resolveLoginRedirectTarget('/passwords?tab=all')).toBe(
+      '/passwords?tab=all'
+    );
+  });
+
+  it('同一オリジンの絶対 URL をアプリ内パスへ変換する', () => {
+    expect(
+      resolveLoginRedirectTarget(
+        'https://example.com/accounts/1?tab=detail#summary',
+        'https://example.com'
+      )
+    ).toBe('/accounts/1?tab=detail#summary');
+  });
+
+  it('外部オリジンの絶対 URL は拒否する', () => {
+    expect(
+      resolveLoginRedirectTarget(
+        'https://evil.example.com/passwords',
+        'https://example.com'
+      )
+    ).toBeNull();
+  });
+
+  it('スキーマ相対 URL は拒否する', () => {
+    expect(resolveLoginRedirectTarget('//evil.example.com/passwords')).toBeNull();
+  });
+
+  it('空文字や不正な値は拒否する', () => {
+    expect(resolveLoginRedirectTarget('')).toBeNull();
+    expect(resolveLoginRedirectTarget('   ')).toBeNull();
+    expect(resolveLoginRedirectTarget('javascript:alert(1)')).toBeNull();
+    expect(resolveLoginRedirectTarget('passwords')).toBeNull();
+  });
+});

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useActionState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { apiClient } from '@/api';
 import {
   AuthService,
@@ -13,6 +13,7 @@ import SubmitButton from '@/components/button/SubmitButton';
 import { ErrorMessage } from '@/components/form/ErrorMessage';
 import { loginAction } from './loginActions';
 import type { LoginFormState } from './loginActions';
+import { resolveLoginRedirectTarget } from './redirect';
 
 const initialState: LoginFormState = {
   errors: {},
@@ -23,6 +24,7 @@ const initialState: LoginFormState = {
 
 const LoginForm: React.FC = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [state, formAction] = useActionState(loginAction, initialState);
 
   useEffect(() => {
@@ -44,7 +46,13 @@ const LoginForm: React.FC = () => {
         localStorage.setItem('auth_user_name', userName);
       }
 
+      const redirectParam = searchParams.get('redirect');
+      const redirectTarget = resolveLoginRedirectTarget(
+        redirectParam,
+        window.location.origin
+      );
       const redirectTo =
+        redirectTarget ||
         state.topPageUrl ||
         (response.success ? extractTopPageUrl(response.data) : null) ||
         '/login';
@@ -54,7 +62,13 @@ const LoginForm: React.FC = () => {
     };
 
     void handleLoginSuccess();
-  }, [state.shouldRedirect, state.accessToken, state.topPageUrl, router]);
+  }, [
+    state.shouldRedirect,
+    state.accessToken,
+    state.topPageUrl,
+    router,
+    searchParams,
+  ]);
 
   return (
     <div className="min-h-screen w-full flex items-center justify-center p-4 bg-[#f0f0f0]">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useActionState, useEffect } from 'react';
+import React, { Suspense, useActionState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { apiClient } from '@/api';
 import {
@@ -22,7 +22,7 @@ const initialState: LoginFormState = {
   shouldRedirect: false,
 };
 
-const LoginForm: React.FC = () => {
+const LoginFormContent: React.FC = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [state, formAction] = useActionState(loginAction, initialState);
@@ -130,5 +130,21 @@ const LoginForm: React.FC = () => {
     </div>
   );
 };
+
+const LoginPageFallback: React.FC = () => (
+  <div className="min-h-screen w-full flex items-center justify-center p-4 bg-[#f0f0f0]">
+    <div className="w-full max-w-md p-8 bg-white/70 rounded shadow-xl backdrop-blur-sm">
+      <h1 className="text-4xl font-bold text-center mb-10 text-[#3e3e3e]">
+        PMAPP
+      </h1>
+    </div>
+  </div>
+);
+
+const LoginForm: React.FC = () => (
+  <Suspense fallback={<LoginPageFallback />}>
+    <LoginFormContent />
+  </Suspense>
+);
 
 export default LoginForm;

--- a/src/app/login/redirect.ts
+++ b/src/app/login/redirect.ts
@@ -1,0 +1,36 @@
+const ABSOLUTE_URL_PROTOCOL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+export const resolveLoginRedirectTarget = (
+  redirectParam: string | null | undefined,
+  origin?: string
+): string | null => {
+  if (typeof redirectParam !== 'string') {
+    return null;
+  }
+
+  const trimmed = redirectParam.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed.startsWith('//') ? null : trimmed;
+  }
+
+  if (!origin || !ABSOLUTE_URL_PROTOCOL_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    const targetUrl = new URL(trimmed);
+    const currentOrigin = new URL(origin).origin;
+
+    if (targetUrl.origin !== currentOrigin) {
+      return null;
+    }
+
+    return `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## 概要
- ログイン画面で `redirect` クエリを読み取り、ログイン成功後の遷移先として最優先で使用するようにしました
- `redirect` の解釈を utility に切り出し、アプリ内相対パスまたは同一オリジンの絶対 URL のみを許可するようにしました
- 外部オリジン、`//` 形式、`javascript:` などの不正な遷移先を拒否するテストを追加しました

## 背景
- Issue #125 の要件は `/login?redirect=...` で指定された URL に、ログイン後に遷移できるようにすることでした
- 既存実装では `top_page_url` は考慮していましたが、`redirect` クエリは見ていませんでした

## 影響
- 未ログイン状態からログイン画面へ誘導された後も、指定された画面へ戻せるようになります
- open redirect を避けつつ必要な画面遷移だけを許可します

## テスト
- `npx jest 'src/app/login/__tests__/redirect.test.ts' 'src/api/services/auth/__tests__/authService.test.ts' --runInBand`
- `npx jest --runTestsByPath 'src/app/(main)/__tests__/AuthSessionGuard.test.tsx'`

Closes #125