### PR TITLE
仮登録パスワード詳細画面タイトル変更

### DIFF
--- a/src/app/(main)/temp-passwords/[uuid]/page.tsx
+++ b/src/app/(main)/temp-passwords/[uuid]/page.tsx
@@ -30,7 +30,7 @@ const Page: React.FC<PageProps> = async ({ params }) => {
   return (
     <main className="flex-1 p-4 md:p-6" role="main">
       <div className="mb-6 flex flex-col gap-4 md:mb-8 md:flex-row md:items-center md:justify-between [&_h2]:mb-0">
-        <Title title="仮登録パスワード登録" />
+        <Title title="仮登録パスワード詳細" />
       </div>
       <PreregistedPasswordDetailView item={item} />
     </main>


### PR DESCRIPTION
## 対象のIssue
なし
<!-- Issue番号を入力 -->

## 概要
仮登録パスワード登録画面を別で実装するため、仮登録パスワード登録→仮登録パスワード詳細 に画面タイトルを変更