### PR TITLE
implement temp password registration page

### DIFF
--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -6,6 +6,7 @@ export { MenuService, extractMenuItems } from './menu/menuService';
 export { PasswordService } from './password/passwordService';
 export {
   PreregistedPasswordService,
+  extractPreregistedPasswordTarget,
   extractPreregistedPasswordIndexRows,
   extractPreregistedPasswordShow,
 } from './preregistedPassword/preregistedPasswordService';
@@ -47,8 +48,12 @@ export type {
   PasswordCreateApiResponse,
 } from './password/passwordService';
 export type {
+  PreregistedPasswordCreateApiResponse,
+  PreregistedPasswordCreateRequest,
+  PreregistedPasswordCreateValidationError,
   PreregistedPasswordIndexRow,
   PreregistedPasswordShowResponse,
+  PreregistedPasswordTargetResponse,
 } from './preregistedPassword/preregistedPasswordService';
 export type {
   UnregistedPasswordIndexRow,

--- a/src/api/services/preregistedPassword/__tests__/preregistedPasswordService.test.ts
+++ b/src/api/services/preregistedPassword/__tests__/preregistedPasswordService.test.ts
@@ -1,6 +1,7 @@
 import {
   extractPreregistedPasswordIndexRows,
   extractPreregistedPasswordShow,
+  extractPreregistedPasswordTarget,
 } from '../preregistedPasswordService';
 
 describe('extractPreregistedPasswordIndexRows', () => {
@@ -80,5 +81,67 @@ describe('extractPreregistedPasswordShow', () => {
   it('不正な形式の場合はnullを返す', () => {
     expect(extractPreregistedPasswordShow(null)).toBeNull();
     expect(extractPreregistedPasswordShow({ data: {} })).toBeNull();
+  });
+});
+
+describe('extractPreregistedPasswordTarget', () => {
+  it('対象情報レスポンスを抽出できる', () => {
+    const result = extractPreregistedPasswordTarget({
+      data: {
+        application: {
+          id: 10,
+          name: 'Slack',
+        },
+        account: {
+          id: 20,
+          name: '@tester',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      application: {
+        id: 10,
+        name: 'Slack',
+      },
+      account: {
+        id: 20,
+        name: '@tester',
+      },
+    });
+  });
+
+  it('アカウントなしの対象情報レスポンスを抽出できる', () => {
+    const result = extractPreregistedPasswordTarget({
+      application: {
+        id: 11,
+        name: 'アカウントなしアプリ',
+      },
+      account: null,
+    });
+
+    expect(result).toEqual({
+      application: {
+        id: 11,
+        name: 'アカウントなしアプリ',
+      },
+      account: null,
+    });
+  });
+
+  it('不正な形式の場合はnullを返す', () => {
+    expect(extractPreregistedPasswordTarget(null)).toBeNull();
+    expect(extractPreregistedPasswordTarget({ data: {} })).toBeNull();
+    expect(
+      extractPreregistedPasswordTarget({
+        data: {
+          application: {
+            id: 'invalid',
+            name: 'Slack',
+          },
+          account: null,
+        },
+      })
+    ).toBeNull();
   });
 });

--- a/src/api/services/preregistedPassword/preregistedPasswordService.ts
+++ b/src/api/services/preregistedPassword/preregistedPasswordService.ts
@@ -1,5 +1,6 @@
 import apiClient from '../../client';
 import { ApiResponse, RequestConfig } from '../../types';
+import { extractValidationErrors } from '../../utils/validationErrorTransformer';
 
 export interface PreregistedPasswordRelation {
   id?: number;
@@ -23,6 +24,16 @@ export interface PreregistedPasswordShowResponse {
   account_name: string;
 }
 
+export interface PreregistedPasswordTargetEntity {
+  id: number;
+  name: string;
+}
+
+export interface PreregistedPasswordTargetResponse {
+  application: PreregistedPasswordTargetEntity;
+  account: PreregistedPasswordTargetEntity | null;
+}
+
 type PreregistedPasswordRaw = {
   uuid?: string;
   created_at?: string;
@@ -33,6 +44,11 @@ type PreregistedPasswordRaw = {
   account?: PreregistedPasswordRelation;
   application_name?: string;
   account_name?: string;
+};
+
+type PreregistedPasswordTargetRaw = {
+  application?: PreregistedPasswordRelation | null;
+  account?: PreregistedPasswordRelation | null;
 };
 
 type ListEnvelope =
@@ -47,9 +63,39 @@ type ShowEnvelope =
       data?: PreregistedPasswordRaw;
     };
 
+type TargetEnvelope =
+  | PreregistedPasswordTargetRaw
+  | {
+      data?: PreregistedPasswordTargetRaw;
+    };
+
 export type PreregistedPasswordDeleteResponse = {
   message?: string;
 };
+
+export interface PreregistedPasswordCreateRequest {
+  preregisted_password: {
+    application_id: number;
+    account_id?: number | null;
+  };
+  [key: string]: unknown;
+}
+
+export interface PreregistedPasswordCreateValidationError {
+  preregisted_password?: {
+    application_id?: string[];
+    account_id?: string[];
+  };
+  [key: string]: unknown;
+}
+
+export type PreregistedPasswordCreateResponse = unknown;
+
+export type PreregistedPasswordCreateApiResponse =
+  | ApiResponse<PreregistedPasswordCreateResponse>
+  | {
+      errors?: PreregistedPasswordCreateValidationError;
+    };
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -131,6 +177,48 @@ export const extractPreregistedPasswordShow = (
   };
 };
 
+const normalizeTargetEntity = (
+  value: unknown
+): PreregistedPasswordTargetEntity | null => {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const id = pickNumber(value.id);
+  const name = pickString(value.name);
+
+  if (typeof id !== 'number' || !name) {
+    return null;
+  }
+
+  return { id, name };
+};
+
+export const extractPreregistedPasswordTarget = (
+  value: unknown
+): PreregistedPasswordTargetResponse | null => {
+  const raw = isObject(value) && isObject(value.data) ? value.data : value;
+
+  if (!isObject(raw)) {
+    return null;
+  }
+
+  const application = normalizeTargetEntity(raw.application);
+  if (!application) {
+    return null;
+  }
+
+  const account = raw.account === null ? null : normalizeTargetEntity(raw.account);
+  if (raw.account !== null && !account) {
+    return null;
+  }
+
+  return {
+    application,
+    account,
+  };
+};
+
 export class PreregistedPasswordService {
   static async index(
     config?: RequestConfig
@@ -143,6 +231,42 @@ export class PreregistedPasswordService {
     config?: RequestConfig
   ): Promise<ApiResponse<ShowEnvelope>> {
     return apiClient.get(`/preregisted-passwords/${encodeURIComponent(uuid)}`, config);
+  }
+
+  static async target(
+    applicationId: string | number,
+    accountId?: string | number,
+    config?: RequestConfig
+  ): Promise<ApiResponse<TargetEnvelope>> {
+    const query = new URLSearchParams({
+      application_id: `${applicationId}`,
+    });
+
+    if (
+      accountId !== undefined &&
+      accountId !== null &&
+      `${accountId}`.length > 0
+    ) {
+      query.set('account_id', `${accountId}`);
+    }
+
+    return apiClient.get(`/preregisted-passwords/target?${query.toString()}`, config);
+  }
+
+  static async create(
+    request: PreregistedPasswordCreateRequest,
+    config?: RequestConfig
+  ): Promise<PreregistedPasswordCreateApiResponse> {
+    const response = await apiClient.post('/preregisted-passwords', request, config);
+
+    if (!response.success && response.validationErrors) {
+      const errors = extractValidationErrors(response);
+      if (errors) {
+        return { errors: errors as PreregistedPasswordCreateValidationError };
+      }
+    }
+
+    return response;
   }
 
   static async delete(

--- a/src/app/(main)/passwords/__tests__/page.test.tsx
+++ b/src/app/(main)/passwords/__tests__/page.test.tsx
@@ -11,8 +11,7 @@ import { getServerAuthConfig } from '@/lib/serverAuthConfig';
 import { AuthService } from '@/api/services/auth/authService';
 
 jest.mock('../_components/PasswordList', () => {
-  const react = require('react');
-  const MockPasswordList = (props: unknown) => react.createElement('div', props);
+  const MockPasswordList = (props: unknown) => <div {...(props as object)} />;
 
   MockPasswordList.displayName = 'MockPasswordList';
 

--- a/src/app/temp-passwords/create/__tests__/page.test.tsx
+++ b/src/app/temp-passwords/create/__tests__/page.test.tsx
@@ -1,23 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import Page from '../page';
 import {
-  extractPreregistedPasswordShow,
+  extractPreregistedPasswordTarget,
   PreregistedPasswordService,
 } from '@/api/services/preregistedPassword/preregistedPasswordService';
 import { guardApiResponse } from '@/app/_lib/responseGuard';
 import { getServerAuthConfig } from '@/lib/serverAuthConfig';
 
-jest.mock('../_components/PreregistedPasswordDetailView', () => {
-  return function MockPreregistedPasswordDetailView() {
-    return <div>detail-view</div>;
+jest.mock('../_components/PreregistedPasswordCreateView', () => {
+  return function MockPreregistedPasswordCreateView() {
+    return <div>create-view</div>;
   };
 });
 
 jest.mock('@/api/services/preregistedPassword/preregistedPasswordService', () => ({
   PreregistedPasswordService: {
-    show: jest.fn(),
+    target: jest.fn(),
   },
-  extractPreregistedPasswordShow: jest.fn(),
+  extractPreregistedPasswordTarget: jest.fn(),
 }));
 
 jest.mock('@/app/_lib/responseGuard', () => ({
@@ -28,32 +28,33 @@ jest.mock('@/lib/serverAuthConfig', () => ({
   getServerAuthConfig: jest.fn(),
 }));
 
-describe('temp password detail page', () => {
-  const mockShow =
-    PreregistedPasswordService.show as jest.MockedFunction<
-      typeof PreregistedPasswordService.show
+describe('temp password create page', () => {
+  const mockTarget =
+    PreregistedPasswordService.target as jest.MockedFunction<
+      typeof PreregistedPasswordService.target
     >;
   const mockExtract =
-    extractPreregistedPasswordShow as jest.MockedFunction<
-      typeof extractPreregistedPasswordShow
+    extractPreregistedPasswordTarget as jest.MockedFunction<
+      typeof extractPreregistedPasswordTarget
     >;
   const mockGuard = guardApiResponse as jest.MockedFunction<typeof guardApiResponse>;
   const mockGetServerAuthConfig =
     getServerAuthConfig as jest.MockedFunction<typeof getServerAuthConfig>;
 
   beforeEach(() => {
-    mockShow.mockResolvedValue({
+    mockTarget.mockResolvedValue({
       success: true,
       data: {},
     });
     mockExtract.mockReturnValue({
-      uuid: 'pre-uuid',
-      password: 'secret',
-      application_id: 1,
-      account_id: 2,
-      created_at: '2026-02-28T12:00:00+09:00',
-      application_name: 'GitHub',
-      account_name: 'octocat',
+      application: {
+        id: 1,
+        name: 'GitHub',
+      },
+      account: {
+        id: 2,
+        name: 'octocat',
+      },
     });
     mockGuard.mockImplementation((value) => value);
     mockGetServerAuthConfig.mockResolvedValue({
@@ -66,10 +67,32 @@ describe('temp password detail page', () => {
   it('モバイル向けの余白クラスでページを表示する', async () => {
     render(
       await Page({
-        params: Promise.resolve({ uuid: 'pre-uuid' }),
+        searchParams: Promise.resolve({
+          application_id: '1',
+          account_id: '2',
+        }),
       })
     );
 
     expect(screen.getByRole('main')).toHaveClass('flex-1', 'p-4', 'md:p-6');
+  });
+
+  it('検索パラメータを使って対象情報を取得する', async () => {
+    await Page({
+      searchParams: Promise.resolve({
+        application_id: '10',
+        account_id: '20',
+      }),
+    });
+
+    expect(mockTarget).toHaveBeenCalledWith(
+      '10',
+      '20',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer token',
+        },
+      })
+    );
   });
 });

--- a/src/app/temp-passwords/create/_components/PreregistedPasswordCreateView.tsx
+++ b/src/app/temp-passwords/create/_components/PreregistedPasswordCreateView.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import CancelButton from '@/components/button/CancelButton';
+import SubmitButton from '@/components/button/SubmitButton';
+import {
+  PreregistedPasswordService,
+  PreregistedPasswordTargetResponse,
+} from '@/api/services/preregistedPassword/preregistedPasswordService';
+
+type PreregistedPasswordCreateViewProps = {
+  item: PreregistedPasswordTargetResponse;
+};
+
+const PreregistedPasswordCreateView: React.FC<
+  PreregistedPasswordCreateViewProps
+> = ({ item }) => {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleCreate = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    const preregistedPassword = item.account
+      ? {
+          application_id: item.application.id,
+          account_id: item.account.id,
+        }
+      : {
+          application_id: item.application.id,
+        };
+
+    const response = await PreregistedPasswordService.create({
+      preregisted_password: preregistedPassword,
+    });
+
+    if ('success' in response && response.success) {
+      router.push('/temp-passwords');
+      return;
+    }
+
+    setErrorMessage(
+      response.errors?.preregisted_password?.application_id?.[0] ??
+        response.errors?.preregisted_password?.account_id?.[0] ??
+        ('error' in response ? response.error?.message : null) ??
+        '仮登録に失敗しました。'
+    );
+    setIsSubmitting(false);
+  };
+
+  return (
+    <>
+      <div className="space-y-6 px-0 text-base md:px-6 md:text-[20px]">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-28">
+          <span className="text-gray-700 font-medium">アプリケーション</span>
+          <span className="flex items-center text-gray-700 font-medium">
+            {item.application.name}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-[150px]">
+          <span className="text-gray-700 font-medium">アカウント名</span>
+          <span className="flex items-center text-gray-700 font-medium">
+            {item.account?.name ?? '-'}
+          </span>
+        </div>
+      </div>
+
+      {errorMessage && (
+        <p className="mt-6 px-0 text-sm text-red-500 md:px-6">{errorMessage}</p>
+      )}
+
+      <div className="mt-10 flex flex-row justify-center gap-4 md:mt-14 md:gap-32">
+        <div className="w-full md:w-auto">
+          <CancelButton to="/temp-passwords" className="w-[162px] md:w-auto" />
+        </div>
+        <div className="w-full md:w-auto">
+          <SubmitButton
+            text="仮登録"
+            onClick={handleCreate}
+            disabled={isSubmitting}
+            className="w-[162px] md:w-36"
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PreregistedPasswordCreateView;

--- a/src/app/temp-passwords/create/_components/PreregistedPasswordCreateView.tsx
+++ b/src/app/temp-passwords/create/_components/PreregistedPasswordCreateView.tsx
@@ -46,12 +46,16 @@ const PreregistedPasswordCreateView: React.FC<
       return;
     }
 
-    const message =
-      'errors' in response
-        ? response.errors?.preregisted_password?.application_id?.[0] ??
-          response.errors?.preregisted_password?.account_id?.[0] ??
-          '仮登録に失敗しました。'
-        : response.error?.message ?? '仮登録に失敗しました。';
+    let message = '仮登録に失敗しました。';
+
+    if ('errors' in response) {
+      message =
+        response.errors?.preregisted_password?.application_id?.[0] ??
+        response.errors?.preregisted_password?.account_id?.[0] ??
+        message;
+    } else if ('error' in response) {
+      message = response.error?.message ?? message;
+    }
 
     setErrorMessage(message);
     setIsSubmitting(false);

--- a/src/app/temp-passwords/create/_components/PreregistedPasswordCreateView.tsx
+++ b/src/app/temp-passwords/create/_components/PreregistedPasswordCreateView.tsx
@@ -46,12 +46,14 @@ const PreregistedPasswordCreateView: React.FC<
       return;
     }
 
-    setErrorMessage(
-      response.errors?.preregisted_password?.application_id?.[0] ??
-        response.errors?.preregisted_password?.account_id?.[0] ??
-        ('error' in response ? response.error?.message : null) ??
-        '仮登録に失敗しました。'
-    );
+    const message =
+      'errors' in response
+        ? response.errors?.preregisted_password?.application_id?.[0] ??
+          response.errors?.preregisted_password?.account_id?.[0] ??
+          '仮登録に失敗しました。'
+        : response.error?.message ?? '仮登録に失敗しました。';
+
+    setErrorMessage(message);
     setIsSubmitting(false);
   };
 

--- a/src/app/temp-passwords/create/_components/__tests__/PreregistedPasswordCreateView.test.tsx
+++ b/src/app/temp-passwords/create/_components/__tests__/PreregistedPasswordCreateView.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+import { PreregistedPasswordService } from '@/api/services/preregistedPassword/preregistedPasswordService';
+import PreregistedPasswordCreateView from '../PreregistedPasswordCreateView';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('PreregistedPasswordCreateView', () => {
+  const mockPush = jest.fn();
+  const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+  const item = {
+    application: {
+      id: 1,
+      name: 'GitHub',
+    },
+    account: {
+      id: 2,
+      name: 'octocat',
+    },
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockPush.mockReset();
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+    } as ReturnType<typeof useRouter>);
+  });
+
+  it('仮登録成功後に一覧へ遷移する', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PreregistedPasswordService, 'create').mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    render(<PreregistedPasswordCreateView item={item} />);
+
+    await user.click(screen.getByRole('button', { name: '仮登録' }));
+
+    await waitFor(() => {
+      expect(PreregistedPasswordService.create).toHaveBeenCalledWith({
+        preregisted_password: {
+          application_id: 1,
+          account_id: 2,
+        },
+      });
+      expect(mockPush).toHaveBeenCalledWith('/temp-passwords');
+    });
+  });
+
+  it('アカウントなしのアプリでも仮登録リクエストを送信する', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PreregistedPasswordService, 'create').mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    render(
+      <PreregistedPasswordCreateView
+        item={{
+          application: {
+            id: 3,
+            name: 'アカウントなしアプリ',
+          },
+          account: null,
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '仮登録' }));
+
+    await waitFor(() => {
+      expect(PreregistedPasswordService.create).toHaveBeenCalledWith({
+        preregisted_password: {
+          application_id: 3,
+        },
+      });
+    });
+  });
+
+  it('バリデーションエラーを表示する', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PreregistedPasswordService, 'create').mockResolvedValue({
+      errors: {
+        preregisted_password: {
+          account_id: ['アカウントが不正です'],
+        },
+      },
+    });
+
+    render(<PreregistedPasswordCreateView item={item} />);
+
+    await user.click(screen.getByRole('button', { name: '仮登録' }));
+
+    expect(await screen.findByText('アカウントが不正です')).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('モバイル向けに詳細項目と操作ボタンを縦積みレイアウトで表示する', () => {
+    render(<PreregistedPasswordCreateView item={item} />);
+
+    expect(screen.getByText('アプリケーション').parentElement).toHaveClass(
+      'flex',
+      'flex-col',
+      'gap-2'
+    );
+    expect(screen.getByText('アカウント名').parentElement).toHaveClass(
+      'flex',
+      'flex-col',
+      'gap-2'
+    );
+    expect(
+      screen.getByRole('link', { name: 'キャンセル' }).parentElement?.parentElement
+    ).toHaveClass('flex', 'flex-row', 'justify-center', 'gap-4');
+    expect(screen.getByRole('link', { name: 'キャンセル' })).toHaveClass(
+      'w-[162px]',
+      'md:w-auto'
+    );
+    expect(screen.getByRole('button', { name: '仮登録' })).toHaveClass(
+      'w-[162px]',
+      'md:w-36'
+    );
+  });
+});

--- a/src/app/temp-passwords/create/page.tsx
+++ b/src/app/temp-passwords/create/page.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { notFound } from 'next/navigation';
+import Title from '@/components/Title';
+import {
+  extractPreregistedPasswordTarget,
+  PreregistedPasswordService,
+} from '@/api/services/preregistedPassword/preregistedPasswordService';
+import { guardApiResponse } from '@/app/_lib/responseGuard';
+import { getServerAuthConfig } from '@/lib/serverAuthConfig';
+import PreregistedPasswordCreateView from './_components/PreregistedPasswordCreateView';
+
+type PageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const getSingleSearchParam = (
+  value: string | string[] | undefined
+): string | undefined => {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+};
+
+const Page: React.FC<PageProps> = async ({ searchParams }) => {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const applicationId = getSingleSearchParam(resolvedSearchParams.application_id);
+  const accountId = getSingleSearchParam(resolvedSearchParams.account_id);
+
+  if (!applicationId) {
+    notFound();
+  }
+
+  const authConfig = await getServerAuthConfig();
+  const response = guardApiResponse(
+    await PreregistedPasswordService.target(applicationId, accountId, authConfig)
+  );
+
+  const item = extractPreregistedPasswordTarget(response.data);
+  if (!item) {
+    notFound();
+  }
+
+  return (
+    <main className="flex-1 p-4 md:p-6" role="main">
+      <div className="mb-6 flex flex-col gap-4 md:mb-8 md:flex-row md:items-center md:justify-between [&_h2]:mb-0">
+        <Title title="仮登録パスワード登録" />
+      </div>
+      <PreregistedPasswordCreateView item={item} />
+    </main>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
## What changed
- added the public `/temp-passwords/create` page for issue #126
- implemented target fetch and preregister create calls in the preregisted password service
- added UI and tests for the preregistration screen
- aligned the account-id handling with the backend update for account-class-free applications

## Why
- issue #126 requires a deep-linkable temp password preregistration screen opened from LINE notifications
- the frontend needed to resolve target application/account data before submission and support the updated backend contract

## Impact
- users can open `/temp-passwords/create?application_id=...` and preregister a temp password from the dedicated screen
- applications without account classification now submit without `account_id`

## Validation
- `npm run lint`
- `npx jest --runTestsByPath 'src/app/temp-passwords/create/_components/__tests__/PreregistedPasswordCreateView.test.tsx' 'src/app/temp-passwords/create/__tests__/page.test.tsx' 'src/api/services/preregistedPassword/__tests__/preregistedPasswordService.test.ts'`
- `npx jest --runTestsByPath 'src/app/(main)/temp-passwords/[uuid]/__tests__/page.test.tsx'`
- `npx jest --runTestsByPath 'src/app/(main)/passwords/__tests__/page.test.tsx'`