### PR TITLE
Fix temp password registration for apps without account

### DIFF
--- a/src/api/services/password/__tests__/passwordService.test.ts
+++ b/src/api/services/password/__tests__/passwordService.test.ts
@@ -1,6 +1,34 @@
 import apiClient from '@/api/client';
 import { extractPasswordIndexRows, PasswordService } from '../passwordService';
 
+describe('PasswordService.create', () => {
+  it('account_id なしでもパスワード登録APIを呼び出せる', async () => {
+    jest.spyOn(apiClient, 'post').mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    const response = await PasswordService.create({
+      password: {
+        password: 'secret',
+        application_id: 10,
+      },
+    });
+
+    expect(response.success).toBe(true);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/passwords',
+      {
+        password: {
+          password: 'secret',
+          application_id: 10,
+        },
+      },
+      undefined
+    );
+  });
+});
+
 describe('PasswordService.latest', () => {
   it('account_id ありで最新パスワード取得APIを呼び出せる', async () => {
     jest.spyOn(apiClient, 'get').mockResolvedValue({

--- a/src/api/services/password/passwordService.ts
+++ b/src/api/services/password/passwordService.ts
@@ -36,7 +36,7 @@ export interface PasswordCreateRequest {
   password: {
     password: string;
     application_id: number;
-    account_id: number;
+    account_id?: number;
   };
   [key: string]: unknown;
 }

--- a/src/app/(main)/temp-passwords/[uuid]/_components/PreregistedPasswordDetailView.tsx
+++ b/src/app/(main)/temp-passwords/[uuid]/_components/PreregistedPasswordDetailView.tsx
@@ -26,7 +26,6 @@ const PreregistedPasswordDetailView: React.FC<
   const canTogglePassword = passwordForDisplay !== '-';
   const canRegister =
     typeof item.application_id === 'number' &&
-    typeof item.account_id === 'number' &&
     passwordForDisplay !== '-';
 
   const handleRegister = async () => {
@@ -36,12 +35,20 @@ const PreregistedPasswordDetailView: React.FC<
 
     setIsSubmitting(true);
 
+    const passwordPayload =
+      typeof item.account_id === 'number'
+        ? {
+            password: passwordForDisplay,
+            application_id: item.application_id!,
+            account_id: item.account_id,
+          }
+        : {
+            password: passwordForDisplay,
+            application_id: item.application_id!,
+          };
+
     const response = await PasswordService.create({
-      password: {
-        password: passwordForDisplay,
-        application_id: item.application_id!,
-        account_id: item.account_id!,
-      },
+      password: passwordPayload,
     });
 
     if ('success' in response && response.success) {

--- a/src/app/(main)/temp-passwords/[uuid]/_components/__tests__/PreregistedPasswordDetailView.test.tsx
+++ b/src/app/(main)/temp-passwords/[uuid]/_components/__tests__/PreregistedPasswordDetailView.test.tsx
@@ -104,6 +104,44 @@ describe('PreregistedPasswordDetailView', () => {
     });
   });
 
+  it('account_id がないアプリでも登録できる', async () => {
+    const user = userEvent.setup();
+
+    jest.spyOn(PasswordService, 'create').mockResolvedValue({
+      success: true,
+      data: {},
+    });
+    jest.spyOn(PreregistedPasswordService, 'delete').mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    render(
+      <PreregistedPasswordDetailView
+        item={{
+          ...item,
+          account_id: undefined,
+          account_name: 'アカウントなし',
+        }}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '登録' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    await waitFor(() => {
+      expect(PasswordService.create).toHaveBeenCalledWith({
+        password: {
+          password: 'secret',
+          application_id: 1,
+        },
+      });
+      expect(PreregistedPasswordService.delete).toHaveBeenCalledWith('pre-uuid');
+      expect(mockPush).toHaveBeenCalledWith('/temp-passwords');
+    });
+  });
+
   it('モバイル向けに詳細項目と操作ボタンを縦積みレイアウトで表示する', () => {
     render(<PreregistedPasswordDetailView item={item} />);
 


### PR DESCRIPTION
## What changed
- allow temp password detail registration when the target application has no `account_id`
- send the password create payload with only `application_id` for account-less applications
- add regression tests for the detail view and password service

## Why
Issue #133 reported that the register button was disabled on the temp password detail screen for applications without an account category.

## Root cause
The frontend required `account_id` both to enable the register button and to build the `/passwords` create request, even though the surrounding flow already supports applications without accounts.

## Impact
Users can now complete registration from the temp password detail screen for account-less applications.

## Validation
- `npx jest --runTestsByPath 'src/app/(main)/temp-passwords/[uuid]/_components/__tests__/PreregistedPasswordDetailView.test.tsx'`
- `npx jest --runTestsByPath 'src/api/services/password/__tests__/passwordService.test.ts'`
- `npm run lint`