### PR TITLE
[codex] fix: ログイン失敗時のエラーメッセージを表示

### DIFF
--- a/src/api/services/auth/authService.ts
+++ b/src/api/services/auth/authService.ts
@@ -27,6 +27,7 @@ export type AppUserRole = 'admin' | 'general' | 'mobile';
 export interface LoginValidationError {
   email?: string[];
   password?: string[];
+  form?: string[];
   [key: string]: unknown;
 }
 
@@ -43,7 +44,7 @@ export class AuthService {
     // バリデーションエラーがある場合は変換して返す
     if (!response.success && response.validationErrors) {
       const errors = extractValidationErrors(response);
-      if (errors) {
+      if (errors && Object.keys(errors).length > 0) {
         return { errors: errors as LoginValidationError };
       }
     }

--- a/src/app/login/__tests__/loginActions.test.ts
+++ b/src/app/login/__tests__/loginActions.test.ts
@@ -1,0 +1,55 @@
+import { loginAction } from '../loginActions';
+import { AuthService } from '@/api/services/auth/authService';
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(async () => ({
+    set: jest.fn(),
+  })),
+}));
+
+jest.mock('@/api/services/auth/authService', () => ({
+  AuthService: {
+    login: jest.fn(),
+  },
+  extractUserNameFromToken: jest.fn(() => null),
+  LoginValidationError: {},
+}));
+
+describe('loginAction', () => {
+  const mockedLogin = AuthService.login as jest.MockedFunction<
+    typeof AuthService.login
+  >;
+
+  beforeEach(() => {
+    mockedLogin.mockReset();
+  });
+
+  it('バックエンドが返した認証失敗メッセージをフォームエラーとして返す', async () => {
+    mockedLogin.mockResolvedValue({
+      success: false,
+      error: {
+        message: 'ログインに失敗しました。',
+        status: 422,
+        code: 'VALIDATION_ERROR',
+      },
+      validationErrors: {
+        message: 'ログインに失敗しました。',
+      },
+    });
+
+    const formData = new FormData();
+    formData.set('email', 'user@example.com');
+    formData.set('password', 'wrong-password');
+
+    const result = await loginAction({}, formData);
+
+    expect(result).toEqual({
+      errors: {
+        form: ['ログインに失敗しました。'],
+      },
+      success: false,
+      message: 'ログインに失敗しました。',
+      shouldRedirect: false,
+    });
+  });
+});

--- a/src/app/login/__tests__/page.test.tsx
+++ b/src/app/login/__tests__/page.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { useActionState } from 'react';
+import LoginPage from '../page';
+import type { LoginFormState } from '../loginActions';
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    useActionState: jest.fn(),
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  })),
+  useSearchParams: jest.fn(() => ({
+    get: jest.fn(() => null),
+  })),
+}));
+
+jest.mock('@/api', () => ({
+  apiClient: {
+    setAuthToken: jest.fn(),
+  },
+}));
+
+jest.mock('@/api/services/auth/authService', () => ({
+  AuthService: {
+    loginStatus: jest.fn(),
+  },
+  extractTopPageUrl: jest.fn(() => null),
+  extractUserName: jest.fn(() => null),
+  extractUserNameFromToken: jest.fn(() => null),
+}));
+
+jest.mock('@/components/button/SubmitButton', () => {
+  return function MockSubmitButton({
+    text,
+    isSubmit,
+  }: {
+    text: string;
+    isSubmit?: boolean;
+  }) {
+    return <button type={isSubmit ? 'submit' : 'button'}>{text}</button>;
+  };
+});
+
+describe('LoginPage', () => {
+  const mockUseActionState = useActionState as jest.MockedFunction<
+    typeof useActionState
+  >;
+
+  beforeEach(() => {
+    const initialState: LoginFormState = {
+      errors: {},
+      success: false,
+      message: '',
+      shouldRedirect: false,
+    };
+
+    mockUseActionState.mockReturnValue([initialState, jest.fn(), false]);
+  });
+
+  it('認証失敗時のフォームエラーをパスワード欄とログインボタンの間に表示する', () => {
+    mockUseActionState.mockReturnValue([
+      {
+        errors: {
+          form: ['メールアドレスまたはパスワードが正しくありません。'],
+        },
+        success: false,
+        message: 'メールアドレスまたはパスワードが正しくありません。',
+        shouldRedirect: false,
+      },
+      jest.fn(),
+      false,
+    ]);
+
+    render(<LoginPage />);
+
+    const errorMessage = screen.getByText(
+      'メールアドレスまたはパスワードが正しくありません。'
+    );
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', { name: 'ログイン' });
+
+    expect(errorMessage).toBeInTheDocument();
+    expect(passwordInput.compareDocumentPosition(errorMessage)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(errorMessage.compareDocumentPosition(submitButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(errorMessage).toHaveClass('text-left');
+  });
+});

--- a/src/app/login/loginActions.ts
+++ b/src/app/login/loginActions.ts
@@ -67,6 +67,10 @@ export async function loginAction(
     const errorMessage =
       'message' in response && typeof response.message === 'string'
         ? response.message
+        : 'error' in response &&
+            response.error &&
+            typeof response.error.message === 'string'
+          ? response.error.message
         : 'ログインに失敗しました。もう一度お試しください。';
 
     return {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -121,6 +121,13 @@ const LoginFormContent: React.FC = () => {
             )}
           </div>
 
+          {state.errors?.form && (
+            <ErrorMessage
+              message={state.errors?.form?.[0]}
+              className="mb-4 mt-0 text-left"
+            />
+          )}
+
           {/* ログインボタン */}
           <div className="text-center">
             <SubmitButton isSubmit text="ログイン" />


### PR DESCRIPTION
## 概要
ログイン失敗時にエラーメッセージが何も表示されない不具合を修正しました。

## 変更内容
- ログイン画面で `errors.form` をパスワード入力欄とログインボタンの間に左寄せ表示
- `loginAction` でバックエンドの 422 エラーメッセージを優先してフォームエラーへ反映
- `AuthService.login` でフィールド別エラーがない 422 レスポンスでもメッセージを落とさないよう修正
- ログイン画面表示テストと `loginAction` の失敗ケーステストを追加

## 原因
バックエンドは認証失敗時に 422 と全体メッセージ `ログインに失敗しました。` を返しますが、フロント側でフィールド別 `errors` がない 422 を適切に扱えておらず、画面に表示するメッセージが失われていました。

## 影響
- ログイン失敗時にユーザーへ失敗理由が表示されるようになります
- バックエンドの認証失敗レスポンス形式に沿ったハンドリングになります

## 確認
- `npx jest src/app/login/__tests__/page.test.tsx src/app/login/__tests__/loginActions.test.ts`
- `npx jest src/api/services/auth/__tests__/authService.test.ts`
- `npm run lint`

Closes #137